### PR TITLE
Quick addition of support for Pam's HarvestCraft 2 trees.

### DIFF
--- a/src/main/resources/data/botanytrees/recipes/pamhc2trees/almond_sapling.json
+++ b/src/main/resources/data/botanytrees/recipes/pamhc2trees/almond_sapling.json
@@ -1,0 +1,57 @@
+{
+  "type": "botanypots:crop",
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "pamhc2trees"
+    },
+    {
+      "type": "forge:item_exists",
+      "item": "pamhc2trees:almond_sapling"
+    }
+  ],
+  "seed": {
+    "item": "pamhc2trees:almond_sapling"
+  },
+  "categories": [
+    "dirt"
+  ],
+  "growthTicks": 2400,
+  "display": {
+    "block": "pamhc2trees:almond_sapling"
+  },
+  "results": [
+    {
+      "chance": 0.5,
+      "output": {
+        "item": "minecraft:jungle_log"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+      "chance": 0.1,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.05,
+      "output": {
+        "item": "minecraft:jungle_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.75,
+      "output": {
+        "item": "pamhc2trees:almonditem"
+      },
+      "minRolls": 1,
+      "maxRolls": 4
+    }
+  ]
+}

--- a/src/main/resources/data/botanytrees/recipes/pamhc2trees/apple_sapling.json
+++ b/src/main/resources/data/botanytrees/recipes/pamhc2trees/apple_sapling.json
@@ -1,0 +1,57 @@
+{
+  "type": "botanypots:crop",
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "pamhc2trees"
+    },
+    {
+      "type": "forge:item_exists",
+      "item": "pamhc2trees:apple_sapling"
+    }
+  ],
+  "seed": {
+    "item": "pamhc2trees:apple_sapling"
+  },
+  "categories": [
+    "dirt"
+  ],
+  "growthTicks": 2400,
+  "display": {
+    "block": "pamhc2trees:apple_sapling"
+  },
+  "results": [
+    {
+      "chance": 0.5,
+      "output": {
+        "item": "minecraft:oak_log"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+      "chance": 0.1,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.05,
+      "output": {
+        "item": "minecraft:oak_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.75,
+      "output": {
+        "item": "minecraft:apple"
+      },
+      "minRolls": 1,
+      "maxRolls": 4
+    }
+  ]
+}

--- a/src/main/resources/data/botanytrees/recipes/pamhc2trees/apricot_sapling.json
+++ b/src/main/resources/data/botanytrees/recipes/pamhc2trees/apricot_sapling.json
@@ -1,0 +1,57 @@
+{
+  "type": "botanypots:crop",
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "pamhc2trees"
+    },
+    {
+      "type": "forge:item_exists",
+      "item": "pamhc2trees:apricot_sapling"
+    }
+  ],
+  "seed": {
+    "item": "pamhc2trees:apricot_sapling"
+  },
+  "categories": [
+    "dirt"
+  ],
+  "growthTicks": 2400,
+  "display": {
+    "block": "pamhc2trees:apricot_sapling"
+  },
+  "results": [
+    {
+      "chance": 0.5,
+      "output": {
+        "item": "minecraft:jungle_log"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+      "chance": 0.1,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.05,
+      "output": {
+        "item": "minecraft:jungle_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.75,
+      "output": {
+        "item": "pamhc2trees:apricotitem"
+      },
+      "minRolls": 1,
+      "maxRolls": 4
+    }
+  ]
+}

--- a/src/main/resources/data/botanytrees/recipes/pamhc2trees/avocado_sapling.json
+++ b/src/main/resources/data/botanytrees/recipes/pamhc2trees/avocado_sapling.json
@@ -1,0 +1,57 @@
+{
+  "type": "botanypots:crop",
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "pamhc2trees"
+    },
+    {
+      "type": "forge:item_exists",
+      "item": "pamhc2trees:avocado_sapling"
+    }
+  ],
+  "seed": {
+    "item": "pamhc2trees:avocado_sapling"
+  },
+  "categories": [
+    "dirt"
+  ],
+  "growthTicks": 2400,
+  "display": {
+    "block": "pamhc2trees:avocado_sapling"
+  },
+  "results": [
+    {
+      "chance": 0.5,
+      "output": {
+        "item": "minecraft:oak_log"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+      "chance": 0.1,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.05,
+      "output": {
+        "item": "minecraft:oak_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.75,
+      "output": {
+        "item": "pamhc2trees:avocadoitem"
+      },
+      "minRolls": 1,
+      "maxRolls": 4
+    }
+  ]
+}

--- a/src/main/resources/data/botanytrees/recipes/pamhc2trees/banana_sapling.json
+++ b/src/main/resources/data/botanytrees/recipes/pamhc2trees/banana_sapling.json
@@ -1,0 +1,57 @@
+{
+  "type": "botanypots:crop",
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "pamhc2trees"
+    },
+    {
+      "type": "forge:item_exists",
+      "item": "pamhc2trees:banana_sapling"
+    }
+  ],
+  "seed": {
+    "item": "pamhc2trees:banana_sapling"
+  },
+  "categories": [
+    "dirt"
+  ],
+  "growthTicks": 2400,
+  "display": {
+    "block": "pamhc2trees:banana_sapling"
+  },
+  "results": [
+    {
+      "chance": 0.5,
+      "output": {
+        "item": "minecraft:jungle_log"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+      "chance": 0.1,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.05,
+      "output": {
+        "item": "minecraft:jungle_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.75,
+      "output": {
+        "item": "pamhc2trees:bananaitem"
+      },
+      "minRolls": 1,
+      "maxRolls": 4
+    }
+  ]
+}

--- a/src/main/resources/data/botanytrees/recipes/pamhc2trees/breadfruit_sapling.json
+++ b/src/main/resources/data/botanytrees/recipes/pamhc2trees/breadfruit_sapling.json
@@ -1,0 +1,57 @@
+{
+  "type": "botanypots:crop",
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "pamhc2trees"
+    },
+    {
+      "type": "forge:item_exists",
+      "item": "pamhc2trees:breadfruit_sapling"
+    }
+  ],
+  "seed": {
+    "item": "pamhc2trees:breadfruit_sapling"
+  },
+  "categories": [
+    "dirt"
+  ],
+  "growthTicks": 2400,
+  "display": {
+    "block": "pamhc2trees:breadfruit_sapling"
+  },
+  "results": [
+    {
+      "chance": 0.5,
+      "output": {
+        "item": "minecraft:jungle_log"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+      "chance": 0.1,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.05,
+      "output": {
+        "item": "minecraft:jungle_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.75,
+      "output": {
+        "item": "pamhc2trees:breadfruititem"
+      },
+      "minRolls": 1,
+      "maxRolls": 4
+    }
+  ]
+}

--- a/src/main/resources/data/botanytrees/recipes/pamhc2trees/candlenut_sapling.json
+++ b/src/main/resources/data/botanytrees/recipes/pamhc2trees/candlenut_sapling.json
@@ -1,0 +1,57 @@
+{
+  "type": "botanypots:crop",
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "pamhc2trees"
+    },
+    {
+      "type": "forge:item_exists",
+      "item": "pamhc2trees:candlenut_sapling"
+    }
+  ],
+  "seed": {
+    "item": "pamhc2trees:candlenut_sapling"
+  },
+  "categories": [
+    "dirt"
+  ],
+  "growthTicks": 2400,
+  "display": {
+    "block": "pamhc2trees:candlenut_sapling"
+  },
+  "results": [
+    {
+      "chance": 0.5,
+      "output": {
+        "item": "minecraft:oak_log"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+      "chance": 0.1,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.05,
+      "output": {
+        "item": "minecraft:oak_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.75,
+      "output": {
+        "item": "pamhc2trees:candlenutitem"
+      },
+      "minRolls": 1,
+      "maxRolls": 4
+    }
+  ]
+}

--- a/src/main/resources/data/botanytrees/recipes/pamhc2trees/cashew_sapling.json
+++ b/src/main/resources/data/botanytrees/recipes/pamhc2trees/cashew_sapling.json
@@ -1,0 +1,57 @@
+{
+  "type": "botanypots:crop",
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "pamhc2trees"
+    },
+    {
+      "type": "forge:item_exists",
+      "item": "pamhc2trees:cashew_sapling"
+    }
+  ],
+  "seed": {
+    "item": "pamhc2trees:cashew_sapling"
+  },
+  "categories": [
+    "dirt"
+  ],
+  "growthTicks": 2400,
+  "display": {
+    "block": "pamhc2trees:cashew_sapling"
+  },
+  "results": [
+    {
+      "chance": 0.5,
+      "output": {
+        "item": "minecraft:jungle_log"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+      "chance": 0.1,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.05,
+      "output": {
+        "item": "minecraft:jungle_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.75,
+      "output": {
+        "item": "pamhc2trees:cashewitem"
+      },
+      "minRolls": 1,
+      "maxRolls": 4
+    }
+  ]
+}

--- a/src/main/resources/data/botanytrees/recipes/pamhc2trees/cherry_sapling.json
+++ b/src/main/resources/data/botanytrees/recipes/pamhc2trees/cherry_sapling.json
@@ -1,0 +1,57 @@
+{
+  "type": "botanypots:crop",
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "pamhc2trees"
+    },
+    {
+      "type": "forge:item_exists",
+      "item": "pamhc2trees:cherry_sapling"
+    }
+  ],
+  "seed": {
+    "item": "pamhc2trees:cherry_sapling"
+  },
+  "categories": [
+    "dirt"
+  ],
+  "growthTicks": 2400,
+  "display": {
+    "block": "pamhc2trees:cherry_sapling"
+  },
+  "results": [
+    {
+      "chance": 0.5,
+      "output": {
+        "item": "minecraft:oak_log"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+      "chance": 0.1,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.05,
+      "output": {
+        "item": "minecraft:oak_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.75,
+      "output": {
+        "item": "pamhc2trees:cherryitem"
+      },
+      "minRolls": 1,
+      "maxRolls": 4
+    }
+  ]
+}

--- a/src/main/resources/data/botanytrees/recipes/pamhc2trees/chestnut_sapling.json
+++ b/src/main/resources/data/botanytrees/recipes/pamhc2trees/chestnut_sapling.json
@@ -1,0 +1,57 @@
+{
+  "type": "botanypots:crop",
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "pamhc2trees"
+    },
+    {
+      "type": "forge:item_exists",
+      "item": "pamhc2trees:chestnut_sapling"
+    }
+  ],
+  "seed": {
+    "item": "pamhc2trees:chestnut_sapling"
+  },
+  "categories": [
+    "dirt"
+  ],
+  "growthTicks": 2400,
+  "display": {
+    "block": "pamhc2trees:chestnut_sapling"
+  },
+  "results": [
+    {
+      "chance": 0.5,
+      "output": {
+        "item": "minecraft:oak_log"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+      "chance": 0.1,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.05,
+      "output": {
+        "item": "minecraft:oak_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.75,
+      "output": {
+        "item": "pamhc2trees:chestnutitem"
+      },
+      "minRolls": 1,
+      "maxRolls": 4
+    }
+  ]
+}

--- a/src/main/resources/data/botanytrees/recipes/pamhc2trees/cinnamon_sapling.json
+++ b/src/main/resources/data/botanytrees/recipes/pamhc2trees/cinnamon_sapling.json
@@ -1,0 +1,57 @@
+{
+  "type": "botanypots:crop",
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "pamhc2trees"
+    },
+    {
+      "type": "forge:item_exists",
+      "item": "pamhc2trees:cinnamon_sapling"
+    }
+  ],
+  "seed": {
+    "item": "pamhc2trees:cinnamon_sapling"
+  },
+  "categories": [
+    "dirt"
+  ],
+  "growthTicks": 2400,
+  "display": {
+    "block": "pamhc2trees:cinnamon_sapling"
+  },
+  "results": [
+    {
+      "chance": 0.01,
+      "output": {
+        "item": "minecraft:jungle_log"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+      "chance": 0.1,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.05,
+      "output": {
+        "item": "minecraft:jungle_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.75,
+      "output": {
+        "item": "pamhc2trees:cinnamonitem"
+      },
+      "minRolls": 1,
+      "maxRolls": 4
+    }
+  ]
+}

--- a/src/main/resources/data/botanytrees/recipes/pamhc2trees/coconut_sapling.json
+++ b/src/main/resources/data/botanytrees/recipes/pamhc2trees/coconut_sapling.json
@@ -1,0 +1,57 @@
+{
+  "type": "botanypots:crop",
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "pamhc2trees"
+    },
+    {
+      "type": "forge:item_exists",
+      "item": "pamhc2trees:coconut_sapling"
+    }
+  ],
+  "seed": {
+    "item": "pamhc2trees:coconut_sapling"
+  },
+  "categories": [
+    "dirt"
+  ],
+  "growthTicks": 2400,
+  "display": {
+    "block": "pamhc2trees:coconut_sapling"
+  },
+  "results": [
+    {
+      "chance": 0.5,
+      "output": {
+        "item": "minecraft:jungle_log"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+      "chance": 0.1,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.05,
+      "output": {
+        "item": "minecraft:jungle_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.75,
+      "output": {
+        "item": "pamhc2trees:coconutitem"
+      },
+      "minRolls": 1,
+      "maxRolls": 4
+    }
+  ]
+}

--- a/src/main/resources/data/botanytrees/recipes/pamhc2trees/date_sapling.json
+++ b/src/main/resources/data/botanytrees/recipes/pamhc2trees/date_sapling.json
@@ -1,0 +1,57 @@
+{
+  "type": "botanypots:crop",
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "pamhc2trees"
+    },
+    {
+      "type": "forge:item_exists",
+      "item": "pamhc2trees:date_sapling"
+    }
+  ],
+  "seed": {
+    "item": "pamhc2trees:date_sapling"
+  },
+  "categories": [
+    "dirt"
+  ],
+  "growthTicks": 2400,
+  "display": {
+    "block": "pamhc2trees:date_sapling"
+  },
+  "results": [
+    {
+      "chance": 0.5,
+      "output": {
+        "item": "minecraft:jungle_log"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+      "chance": 0.1,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.05,
+      "output": {
+        "item": "minecraft:jungle_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.75,
+      "output": {
+        "item": "pamhc2trees:dateitem"
+      },
+      "minRolls": 1,
+      "maxRolls": 4
+    }
+  ]
+}

--- a/src/main/resources/data/botanytrees/recipes/pamhc2trees/dragonfruit_sapling.json
+++ b/src/main/resources/data/botanytrees/recipes/pamhc2trees/dragonfruit_sapling.json
@@ -1,0 +1,57 @@
+{
+  "type": "botanypots:crop",
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "pamhc2trees"
+    },
+    {
+      "type": "forge:item_exists",
+      "item": "pamhc2trees:dragonfruit_sapling"
+    }
+  ],
+  "seed": {
+    "item": "pamhc2trees:dragonfruit_sapling"
+  },
+  "categories": [
+    "dirt"
+  ],
+  "growthTicks": 2400,
+  "display": {
+    "block": "pamhc2trees:dragonfruit_sapling"
+  },
+  "results": [
+    {
+      "chance": 0.5,
+      "output": {
+        "item": "minecraft:jungle_log"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+      "chance": 0.1,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.05,
+      "output": {
+        "item": "minecraft:jungle_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.75,
+      "output": {
+        "item": "pamhc2trees:dragonfruititem"
+      },
+      "minRolls": 1,
+      "maxRolls": 4
+    }
+  ]
+}

--- a/src/main/resources/data/botanytrees/recipes/pamhc2trees/durian_sapling.json
+++ b/src/main/resources/data/botanytrees/recipes/pamhc2trees/durian_sapling.json
@@ -1,0 +1,57 @@
+{
+  "type": "botanypots:crop",
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "pamhc2trees"
+    },
+    {
+      "type": "forge:item_exists",
+      "item": "pamhc2trees:durian_sapling"
+    }
+  ],
+  "seed": {
+    "item": "pamhc2trees:durian_sapling"
+  },
+  "categories": [
+    "dirt"
+  ],
+  "growthTicks": 2400,
+  "display": {
+    "block": "pamhc2trees:durian_sapling"
+  },
+  "results": [
+    {
+      "chance": 0.5,
+      "output": {
+        "item": "minecraft:jungle_log"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+      "chance": 0.1,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.05,
+      "output": {
+        "item": "minecraft:jungle_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.75,
+      "output": {
+        "item": "pamhc2trees:durianitem"
+      },
+      "minRolls": 1,
+      "maxRolls": 4
+    }
+  ]
+}

--- a/src/main/resources/data/botanytrees/recipes/pamhc2trees/fig_sapling.json
+++ b/src/main/resources/data/botanytrees/recipes/pamhc2trees/fig_sapling.json
@@ -1,0 +1,57 @@
+{
+  "type": "botanypots:crop",
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "pamhc2trees"
+    },
+    {
+      "type": "forge:item_exists",
+      "item": "pamhc2trees:fig_sapling"
+    }
+  ],
+  "seed": {
+    "item": "pamhc2trees:fig_sapling"
+  },
+  "categories": [
+    "dirt"
+  ],
+  "growthTicks": 2400,
+  "display": {
+    "block": "pamhc2trees:fig_sapling"
+  },
+  "results": [
+    {
+      "chance": 0.5,
+      "output": {
+        "item": "minecraft:jungle_log"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+      "chance": 0.1,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.05,
+      "output": {
+        "item": "minecraft:jungle_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.75,
+      "output": {
+        "item": "pamhc2trees:figitem"
+      },
+      "minRolls": 1,
+      "maxRolls": 4
+    }
+  ]
+}

--- a/src/main/resources/data/botanytrees/recipes/pamhc2trees/gooseberry_sapling.json
+++ b/src/main/resources/data/botanytrees/recipes/pamhc2trees/gooseberry_sapling.json
@@ -1,0 +1,57 @@
+{
+  "type": "botanypots:crop",
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "pamhc2trees"
+    },
+    {
+      "type": "forge:item_exists",
+      "item": "pamhc2trees:gooseberry_sapling"
+    }
+  ],
+  "seed": {
+    "item": "pamhc2trees:gooseberry_sapling"
+  },
+  "categories": [
+    "dirt"
+  ],
+  "growthTicks": 2400,
+  "display": {
+    "block": "pamhc2trees:gooseberry_sapling"
+  },
+  "results": [
+    {
+      "chance": 0.5,
+      "output": {
+        "item": "minecraft:oak_log"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+      "chance": 0.1,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.05,
+      "output": {
+        "item": "minecraft:oak_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.75,
+      "output": {
+        "item": "pamhc2trees:gooseberryitem"
+      },
+      "minRolls": 1,
+      "maxRolls": 4
+    }
+  ]
+}

--- a/src/main/resources/data/botanytrees/recipes/pamhc2trees/grapefruit_sapling.json
+++ b/src/main/resources/data/botanytrees/recipes/pamhc2trees/grapefruit_sapling.json
@@ -1,0 +1,57 @@
+{
+  "type": "botanypots:crop",
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "pamhc2trees"
+    },
+    {
+      "type": "forge:item_exists",
+      "item": "pamhc2trees:grapefruit_sapling"
+    }
+  ],
+  "seed": {
+    "item": "pamhc2trees:grapefruit_sapling"
+  },
+  "categories": [
+    "dirt"
+  ],
+  "growthTicks": 2400,
+  "display": {
+    "block": "pamhc2trees:grapefruit_sapling"
+  },
+  "results": [
+    {
+      "chance": 0.5,
+      "output": {
+        "item": "minecraft:jungle_log"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+      "chance": 0.1,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.05,
+      "output": {
+        "item": "minecraft:jungle_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.75,
+      "output": {
+        "item": "pamhc2trees:grapefruititem"
+      },
+      "minRolls": 1,
+      "maxRolls": 4
+    }
+  ]
+}

--- a/src/main/resources/data/botanytrees/recipes/pamhc2trees/guava_sapling.json
+++ b/src/main/resources/data/botanytrees/recipes/pamhc2trees/guava_sapling.json
@@ -1,0 +1,57 @@
+{
+  "type": "botanypots:crop",
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "pamhc2trees"
+    },
+    {
+      "type": "forge:item_exists",
+      "item": "pamhc2trees:guava_sapling"
+    }
+  ],
+  "seed": {
+    "item": "pamhc2trees:guava_sapling"
+  },
+  "categories": [
+    "dirt"
+  ],
+  "growthTicks": 2400,
+  "display": {
+    "block": "pamhc2trees:guava_sapling"
+  },
+  "results": [
+    {
+      "chance": 0.5,
+      "output": {
+        "item": "minecraft:jungle_log"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+      "chance": 0.1,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.05,
+      "output": {
+        "item": "minecraft:jungle_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.75,
+      "output": {
+        "item": "pamhc2trees:guavaitem"
+      },
+      "minRolls": 1,
+      "maxRolls": 4
+    }
+  ]
+}

--- a/src/main/resources/data/botanytrees/recipes/pamhc2trees/hazelnut_sapling.json
+++ b/src/main/resources/data/botanytrees/recipes/pamhc2trees/hazelnut_sapling.json
@@ -1,0 +1,57 @@
+{
+  "type": "botanypots:crop",
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "pamhc2trees"
+    },
+    {
+      "type": "forge:item_exists",
+      "item": "pamhc2trees:hazelnut_sapling"
+    }
+  ],
+  "seed": {
+    "item": "pamhc2trees:hazelnut_sapling"
+  },
+  "categories": [
+    "dirt"
+  ],
+  "growthTicks": 2400,
+  "display": {
+    "block": "pamhc2trees:hazelnut_sapling"
+  },
+  "results": [
+    {
+      "chance": 0.5,
+      "output": {
+        "item": "minecraft:oak_log"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+      "chance": 0.1,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.05,
+      "output": {
+        "item": "minecraft:oak_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.75,
+      "output": {
+        "item": "pamhc2trees:hazelnutitem"
+      },
+      "minRolls": 1,
+      "maxRolls": 4
+    }
+  ]
+}

--- a/src/main/resources/data/botanytrees/recipes/pamhc2trees/jackfruit_sapling.json
+++ b/src/main/resources/data/botanytrees/recipes/pamhc2trees/jackfruit_sapling.json
@@ -1,0 +1,57 @@
+{
+  "type": "botanypots:crop",
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "pamhc2trees"
+    },
+    {
+      "type": "forge:item_exists",
+      "item": "pamhc2trees:jackfruit_sapling"
+    }
+  ],
+  "seed": {
+    "item": "pamhc2trees:jackfruit_sapling"
+  },
+  "categories": [
+    "dirt"
+  ],
+  "growthTicks": 2400,
+  "display": {
+    "block": "pamhc2trees:jackfruit_sapling"
+  },
+  "results": [
+    {
+      "chance": 0.5,
+      "output": {
+        "item": "minecraft:jungle_log"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+      "chance": 0.1,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.05,
+      "output": {
+        "item": "minecraft:jungle_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.75,
+      "output": {
+        "item": "pamhc2trees:jackfruititem"
+      },
+      "minRolls": 1,
+      "maxRolls": 4
+    }
+  ]
+}

--- a/src/main/resources/data/botanytrees/recipes/pamhc2trees/lemon_sapling.json
+++ b/src/main/resources/data/botanytrees/recipes/pamhc2trees/lemon_sapling.json
@@ -1,0 +1,57 @@
+{
+  "type": "botanypots:crop",
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "pamhc2trees"
+    },
+    {
+      "type": "forge:item_exists",
+      "item": "pamhc2trees:lemon_sapling"
+    }
+  ],
+  "seed": {
+    "item": "pamhc2trees:lemon_sapling"
+  },
+  "categories": [
+    "dirt"
+  ],
+  "growthTicks": 2400,
+  "display": {
+    "block": "pamhc2trees:lemon_sapling"
+  },
+  "results": [
+    {
+      "chance": 0.5,
+      "output": {
+        "item": "minecraft:oak_log"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+      "chance": 0.1,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.05,
+      "output": {
+        "item": "minecraft:oak_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.75,
+      "output": {
+        "item": "pamhc2trees:lemonitem"
+      },
+      "minRolls": 1,
+      "maxRolls": 4
+    }
+  ]
+}

--- a/src/main/resources/data/botanytrees/recipes/pamhc2trees/lime_sapling.json
+++ b/src/main/resources/data/botanytrees/recipes/pamhc2trees/lime_sapling.json
@@ -1,0 +1,57 @@
+{
+  "type": "botanypots:crop",
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "pamhc2trees"
+    },
+    {
+      "type": "forge:item_exists",
+      "item": "pamhc2trees:lime_sapling"
+    }
+  ],
+  "seed": {
+    "item": "pamhc2trees:lime_sapling"
+  },
+  "categories": [
+    "dirt"
+  ],
+  "growthTicks": 2400,
+  "display": {
+    "block": "pamhc2trees:lime_sapling"
+  },
+  "results": [
+    {
+      "chance": 0.5,
+      "output": {
+        "item": "minecraft:jungle_log"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+      "chance": 0.1,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.05,
+      "output": {
+        "item": "minecraft:jungle_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.75,
+      "output": {
+        "item": "pamhc2trees:limeitem"
+      },
+      "minRolls": 1,
+      "maxRolls": 4
+    }
+  ]
+}

--- a/src/main/resources/data/botanytrees/recipes/pamhc2trees/lychee_sapling.json
+++ b/src/main/resources/data/botanytrees/recipes/pamhc2trees/lychee_sapling.json
@@ -1,0 +1,57 @@
+{
+  "type": "botanypots:crop",
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "pamhc2trees"
+    },
+    {
+      "type": "forge:item_exists",
+      "item": "pamhc2trees:lychee_sapling"
+    }
+  ],
+  "seed": {
+    "item": "pamhc2trees:lychee_sapling"
+  },
+  "categories": [
+    "dirt"
+  ],
+  "growthTicks": 2400,
+  "display": {
+    "block": "pamhc2trees:lychee_sapling"
+  },
+  "results": [
+    {
+      "chance": 0.5,
+      "output": {
+        "item": "minecraft:jungle_log"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+      "chance": 0.1,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.05,
+      "output": {
+        "item": "minecraft:jungle_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.75,
+      "output": {
+        "item": "pamhc2trees:lycheeitem"
+      },
+      "minRolls": 1,
+      "maxRolls": 4
+    }
+  ]
+}

--- a/src/main/resources/data/botanytrees/recipes/pamhc2trees/mango_sapling.json
+++ b/src/main/resources/data/botanytrees/recipes/pamhc2trees/mango_sapling.json
@@ -1,0 +1,57 @@
+{
+  "type": "botanypots:crop",
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "pamhc2trees"
+    },
+    {
+      "type": "forge:item_exists",
+      "item": "pamhc2trees:mango_sapling"
+    }
+  ],
+  "seed": {
+    "item": "pamhc2trees:mango_sapling"
+  },
+  "categories": [
+    "dirt"
+  ],
+  "growthTicks": 2400,
+  "display": {
+    "block": "pamhc2trees:mango_sapling"
+  },
+  "results": [
+    {
+      "chance": 0.5,
+      "output": {
+        "item": "minecraft:jungle_log"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+      "chance": 0.1,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.05,
+      "output": {
+        "item": "minecraft:jungle_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.75,
+      "output": {
+        "item": "pamhc2trees:mangoitem"
+      },
+      "minRolls": 1,
+      "maxRolls": 4
+    }
+  ]
+}

--- a/src/main/resources/data/botanytrees/recipes/pamhc2trees/maple_sapling.json
+++ b/src/main/resources/data/botanytrees/recipes/pamhc2trees/maple_sapling.json
@@ -1,0 +1,57 @@
+{
+  "type": "botanypots:crop",
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "pamhc2trees"
+    },
+    {
+      "type": "forge:item_exists",
+      "item": "pamhc2trees:maple_sapling"
+    }
+  ],
+  "seed": {
+    "item": "pamhc2trees:maple_sapling"
+  },
+  "categories": [
+    "dirt"
+  ],
+  "growthTicks": 2400,
+  "display": {
+    "block": "pamhc2trees:maplesyrup_sapling"
+  },
+  "results": [
+    {
+      "chance": 0.1,
+      "output": {
+        "item": "minecraft:spruce_log"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+      "chance": 0.1,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.05,
+      "output": {
+        "item": "minecraft:spruce_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.75,
+      "output": {
+        "item": "pamhc2trees:mapleitem"
+      },
+      "minRolls": 1,
+      "maxRolls": 4
+    }
+  ]
+}

--- a/src/main/resources/data/botanytrees/recipes/pamhc2trees/nutmeg_sapling.json
+++ b/src/main/resources/data/botanytrees/recipes/pamhc2trees/nutmeg_sapling.json
@@ -1,0 +1,57 @@
+{
+  "type": "botanypots:crop",
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "pamhc2trees"
+    },
+    {
+      "type": "forge:item_exists",
+      "item": "pamhc2trees:nutmeg_sapling"
+    }
+  ],
+  "seed": {
+    "item": "pamhc2trees:nutmeg_sapling"
+  },
+  "categories": [
+    "dirt"
+  ],
+  "growthTicks": 2400,
+  "display": {
+    "block": "pamhc2trees:nutmeg_sapling"
+  },
+  "results": [
+    {
+      "chance": 0.5,
+      "output": {
+        "item": "minecraft:oak_log"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+      "chance": 0.1,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.05,
+      "output": {
+        "item": "minecraft:oak_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.75,
+      "output": {
+        "item": "pamhc2trees:nutmegitem"
+      },
+      "minRolls": 1,
+      "maxRolls": 4
+    }
+  ]
+}

--- a/src/main/resources/data/botanytrees/recipes/pamhc2trees/olice_sapling.json
+++ b/src/main/resources/data/botanytrees/recipes/pamhc2trees/olice_sapling.json
@@ -1,0 +1,57 @@
+{
+  "type": "botanypots:crop",
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "pamhc2trees"
+    },
+    {
+      "type": "forge:item_exists",
+      "item": "pamhc2trees:olice_sapling"
+    }
+  ],
+  "seed": {
+    "item": "pamhc2trees:olice_sapling"
+  },
+  "categories": [
+    "dirt"
+  ],
+  "growthTicks": 2400,
+  "display": {
+    "block": "pamhc2trees:olice_sapling"
+  },
+  "results": [
+    {
+      "chance": 0.5,
+      "output": {
+        "item": "minecraft:jungle_log"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+      "chance": 0.1,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.05,
+      "output": {
+        "item": "minecraft:jungle_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.75,
+      "output": {
+        "item": "pamhc2trees:oliceitem"
+      },
+      "minRolls": 1,
+      "maxRolls": 4
+    }
+  ]
+}

--- a/src/main/resources/data/botanytrees/recipes/pamhc2trees/orange_sapling.json
+++ b/src/main/resources/data/botanytrees/recipes/pamhc2trees/orange_sapling.json
@@ -1,0 +1,57 @@
+{
+  "type": "botanypots:crop",
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "pamhc2trees"
+    },
+    {
+      "type": "forge:item_exists",
+      "item": "pamhc2trees:orange_sapling"
+    }
+  ],
+  "seed": {
+    "item": "pamhc2trees:orange_sapling"
+  },
+  "categories": [
+    "dirt"
+  ],
+  "growthTicks": 2400,
+  "display": {
+    "block": "pamhc2trees:orange_sapling"
+  },
+  "results": [
+    {
+      "chance": 0.5,
+      "output": {
+        "item": "minecraft:oak_log"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+      "chance": 0.1,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.05,
+      "output": {
+        "item": "minecraft:oak_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.75,
+      "output": {
+        "item": "pamhc2trees:orangeitem"
+      },
+      "minRolls": 1,
+      "maxRolls": 4
+    }
+  ]
+}

--- a/src/main/resources/data/botanytrees/recipes/pamhc2trees/papaya_sapling.json
+++ b/src/main/resources/data/botanytrees/recipes/pamhc2trees/papaya_sapling.json
@@ -1,0 +1,57 @@
+{
+  "type": "botanypots:crop",
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "pamhc2trees"
+    },
+    {
+      "type": "forge:item_exists",
+      "item": "pamhc2trees:papaya_sapling"
+    }
+  ],
+  "seed": {
+    "item": "pamhc2trees:papaya_sapling"
+  },
+  "categories": [
+    "dirt"
+  ],
+  "growthTicks": 2400,
+  "display": {
+    "block": "pamhc2trees:papaya_sapling"
+  },
+  "results": [
+    {
+      "chance": 0.5,
+      "output": {
+        "item": "minecraft:jungle_log"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+      "chance": 0.1,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.05,
+      "output": {
+        "item": "minecraft:jungle_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.75,
+      "output": {
+        "item": "pamhc2trees:papayaitem"
+      },
+      "minRolls": 1,
+      "maxRolls": 4
+    }
+  ]
+}

--- a/src/main/resources/data/botanytrees/recipes/pamhc2trees/paperbark_sapling.json
+++ b/src/main/resources/data/botanytrees/recipes/pamhc2trees/paperbark_sapling.json
@@ -1,0 +1,57 @@
+{
+  "type": "botanypots:crop",
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "pamhc2trees"
+    },
+    {
+      "type": "forge:item_exists",
+      "item": "pamhc2trees:paperbark_sapling"
+    }
+  ],
+  "seed": {
+    "item": "pamhc2trees:paperbark_sapling"
+  },
+  "categories": [
+    "dirt"
+  ],
+  "growthTicks": 2400,
+  "display": {
+    "block": "pamhc2trees:paperbark_sapling"
+  },
+  "results": [
+    {
+      "chance": 0.01,
+      "output": {
+        "item": "minecraft:jungle_log"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+      "chance": 0.1,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.05,
+      "output": {
+        "item": "minecraft:jungle_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.75,
+      "output": {
+        "item": "minecraft:paper"
+      },
+      "minRolls": 1,
+      "maxRolls": 4
+    }
+  ]
+}

--- a/src/main/resources/data/botanytrees/recipes/pamhc2trees/passionfruit_sapling.json
+++ b/src/main/resources/data/botanytrees/recipes/pamhc2trees/passionfruit_sapling.json
@@ -1,0 +1,57 @@
+{
+  "type": "botanypots:crop",
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "pamhc2trees"
+    },
+    {
+      "type": "forge:item_exists",
+      "item": "pamhc2trees:passionfruit_sapling"
+    }
+  ],
+  "seed": {
+    "item": "pamhc2trees:passionfruit_sapling"
+  },
+  "categories": [
+    "dirt"
+  ],
+  "growthTicks": 2400,
+  "display": {
+    "block": "pamhc2trees:passionfruit_sapling"
+  },
+  "results": [
+    {
+      "chance": 0.5,
+      "output": {
+        "item": "minecraft:jungle_log"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+      "chance": 0.1,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.05,
+      "output": {
+        "item": "minecraft:jungle_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.75,
+      "output": {
+        "item": "pamhc2trees:passionfruititem"
+      },
+      "minRolls": 1,
+      "maxRolls": 4
+    }
+  ]
+}

--- a/src/main/resources/data/botanytrees/recipes/pamhc2trees/pawpaw_sapling.json
+++ b/src/main/resources/data/botanytrees/recipes/pamhc2trees/pawpaw_sapling.json
@@ -1,0 +1,57 @@
+{
+  "type": "botanypots:crop",
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "pamhc2trees"
+    },
+    {
+      "type": "forge:item_exists",
+      "item": "pamhc2trees:pawpaw_sapling"
+    }
+  ],
+  "seed": {
+    "item": "pamhc2trees:pawpaw_sapling"
+  },
+  "categories": [
+    "dirt"
+  ],
+  "growthTicks": 2400,
+  "display": {
+    "block": "pamhc2trees:pawpaw_sapling"
+  },
+  "results": [
+    {
+      "chance": 0.5,
+      "output": {
+        "item": "minecraft:oak_log"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+      "chance": 0.1,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.05,
+      "output": {
+        "item": "minecraft:oak_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.75,
+      "output": {
+        "item": "pamhc2trees:pawpawitem"
+      },
+      "minRolls": 1,
+      "maxRolls": 4
+    }
+  ]
+}

--- a/src/main/resources/data/botanytrees/recipes/pamhc2trees/peach_sapling.json
+++ b/src/main/resources/data/botanytrees/recipes/pamhc2trees/peach_sapling.json
@@ -1,0 +1,57 @@
+{
+  "type": "botanypots:crop",
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "pamhc2trees"
+    },
+    {
+      "type": "forge:item_exists",
+      "item": "pamhc2trees:peach_sapling"
+    }
+  ],
+  "seed": {
+    "item": "pamhc2trees:peach_sapling"
+  },
+  "categories": [
+    "dirt"
+  ],
+  "growthTicks": 2400,
+  "display": {
+    "block": "pamhc2trees:peach_sapling"
+  },
+  "results": [
+    {
+      "chance": 0.5,
+      "output": {
+        "item": "minecraft:oak_log"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+      "chance": 0.1,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.05,
+      "output": {
+        "item": "minecraft:oak_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.75,
+      "output": {
+        "item": "pamhc2trees:peachitem"
+      },
+      "minRolls": 1,
+      "maxRolls": 4
+    }
+  ]
+}

--- a/src/main/resources/data/botanytrees/recipes/pamhc2trees/pear_sapling.json
+++ b/src/main/resources/data/botanytrees/recipes/pamhc2trees/pear_sapling.json
@@ -1,0 +1,57 @@
+{
+  "type": "botanypots:crop",
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "pamhc2trees"
+    },
+    {
+      "type": "forge:item_exists",
+      "item": "pamhc2trees:pear_sapling"
+    }
+  ],
+  "seed": {
+    "item": "pamhc2trees:pear_sapling"
+  },
+  "categories": [
+    "dirt"
+  ],
+  "growthTicks": 2400,
+  "display": {
+    "block": "pamhc2trees:pear_sapling"
+  },
+  "results": [
+    {
+      "chance": 0.5,
+      "output": {
+        "item": "minecraft:oak_log"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+      "chance": 0.1,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.05,
+      "output": {
+        "item": "minecraft:oak_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.75,
+      "output": {
+        "item": "pamhc2trees:pearitem"
+      },
+      "minRolls": 1,
+      "maxRolls": 4
+    }
+  ]
+}

--- a/src/main/resources/data/botanytrees/recipes/pamhc2trees/pecan_sapling.json
+++ b/src/main/resources/data/botanytrees/recipes/pamhc2trees/pecan_sapling.json
@@ -1,0 +1,57 @@
+{
+  "type": "botanypots:crop",
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "pamhc2trees"
+    },
+    {
+      "type": "forge:item_exists",
+      "item": "pamhc2trees:pecan_sapling"
+    }
+  ],
+  "seed": {
+    "item": "pamhc2trees:pecan_sapling"
+  },
+  "categories": [
+    "dirt"
+  ],
+  "growthTicks": 2400,
+  "display": {
+    "block": "pamhc2trees:pecan_sapling"
+  },
+  "results": [
+    {
+      "chance": 0.5,
+      "output": {
+        "item": "minecraft:jungle_log"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+      "chance": 0.1,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.05,
+      "output": {
+        "item": "minecraft:jungle_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.75,
+      "output": {
+        "item": "pamhc2trees:pecanitem"
+      },
+      "minRolls": 1,
+      "maxRolls": 4
+    }
+  ]
+}

--- a/src/main/resources/data/botanytrees/recipes/pamhc2trees/peppercorn_sapling.json
+++ b/src/main/resources/data/botanytrees/recipes/pamhc2trees/peppercorn_sapling.json
@@ -1,0 +1,57 @@
+{
+  "type": "botanypots:crop",
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "pamhc2trees"
+    },
+    {
+      "type": "forge:item_exists",
+      "item": "pamhc2trees:peppercorn_sapling"
+    }
+  ],
+  "seed": {
+    "item": "pamhc2trees:peppercorn_sapling"
+  },
+  "categories": [
+    "dirt"
+  ],
+  "growthTicks": 2400,
+  "display": {
+    "block": "pamhc2trees:peppercorn_sapling"
+  },
+  "results": [
+    {
+      "chance": 0.5,
+      "output": {
+        "item": "minecraft:jungle_log"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+      "chance": 0.1,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.05,
+      "output": {
+        "item": "minecraft:jungle_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.75,
+      "output": {
+        "item": "pamhc2trees:peppercornitem"
+      },
+      "minRolls": 1,
+      "maxRolls": 4
+    }
+  ]
+}

--- a/src/main/resources/data/botanytrees/recipes/pamhc2trees/persimmon_sapling.json
+++ b/src/main/resources/data/botanytrees/recipes/pamhc2trees/persimmon_sapling.json
@@ -1,0 +1,57 @@
+{
+  "type": "botanypots:crop",
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "pamhc2trees"
+    },
+    {
+      "type": "forge:item_exists",
+      "item": "pamhc2trees:persimmon_sapling"
+    }
+  ],
+  "seed": {
+    "item": "pamhc2trees:persimmon_sapling"
+  },
+  "categories": [
+    "dirt"
+  ],
+  "growthTicks": 2400,
+  "display": {
+    "block": "pamhc2trees:persimmon_sapling"
+  },
+  "results": [
+    {
+      "chance": 0.5,
+      "output": {
+        "item": "minecraft:jungle_log"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+      "chance": 0.1,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.05,
+      "output": {
+        "item": "minecraft:jungle_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.75,
+      "output": {
+        "item": "pamhc2trees:persimmonitem"
+      },
+      "minRolls": 1,
+      "maxRolls": 4
+    }
+  ]
+}

--- a/src/main/resources/data/botanytrees/recipes/pamhc2trees/pinenut_sapling.json
+++ b/src/main/resources/data/botanytrees/recipes/pamhc2trees/pinenut_sapling.json
@@ -1,0 +1,57 @@
+{
+  "type": "botanypots:crop",
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "pamhc2trees"
+    },
+    {
+      "type": "forge:item_exists",
+      "item": "pamhc2trees:pinenut_sapling"
+    }
+  ],
+  "seed": {
+    "item": "pamhc2trees:pinenut_sapling"
+  },
+  "categories": [
+    "dirt"
+  ],
+  "growthTicks": 2400,
+  "display": {
+    "block": "pamhc2trees:pinenut_sapling"
+  },
+  "results": [
+    {
+      "chance": 0.5,
+      "output": {
+        "item": "minecraft:spruce_log"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+      "chance": 0.1,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.05,
+      "output": {
+        "item": "minecraft:spruce_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.75,
+      "output": {
+        "item": "pamhc2trees:pinenutitem"
+      },
+      "minRolls": 1,
+      "maxRolls": 4
+    }
+  ]
+}

--- a/src/main/resources/data/botanytrees/recipes/pamhc2trees/pistachio_sapling.json
+++ b/src/main/resources/data/botanytrees/recipes/pamhc2trees/pistachio_sapling.json
@@ -1,0 +1,57 @@
+{
+  "type": "botanypots:crop",
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "pamhc2trees"
+    },
+    {
+      "type": "forge:item_exists",
+      "item": "pamhc2trees:pistachio_sapling"
+    }
+  ],
+  "seed": {
+    "item": "pamhc2trees:pistachio_sapling"
+  },
+  "categories": [
+    "dirt"
+  ],
+  "growthTicks": 2400,
+  "display": {
+    "block": "pamhc2trees:pistachio_sapling"
+  },
+  "results": [
+    {
+      "chance": 0.5,
+      "output": {
+        "item": "minecraft:jungle_log"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+      "chance": 0.1,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.05,
+      "output": {
+        "item": "minecraft:jungle_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.75,
+      "output": {
+        "item": "pamhc2trees:pistachioitem"
+      },
+      "minRolls": 1,
+      "maxRolls": 4
+    }
+  ]
+}

--- a/src/main/resources/data/botanytrees/recipes/pamhc2trees/plum_sapling.json
+++ b/src/main/resources/data/botanytrees/recipes/pamhc2trees/plum_sapling.json
@@ -1,0 +1,57 @@
+{
+  "type": "botanypots:crop",
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "pamhc2trees"
+    },
+    {
+      "type": "forge:item_exists",
+      "item": "pamhc2trees:plum_sapling"
+    }
+  ],
+  "seed": {
+    "item": "pamhc2trees:plum_sapling"
+  },
+  "categories": [
+    "dirt"
+  ],
+  "growthTicks": 2400,
+  "display": {
+    "block": "pamhc2trees:plum_sapling"
+  },
+  "results": [
+    {
+      "chance": 0.5,
+      "output": {
+        "item": "minecraft:oak_log"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+      "chance": 0.1,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.05,
+      "output": {
+        "item": "minecraft:oak_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.75,
+      "output": {
+        "item": "pamhc2trees:plumitem"
+      },
+      "minRolls": 1,
+      "maxRolls": 4
+    }
+  ]
+}

--- a/src/main/resources/data/botanytrees/recipes/pamhc2trees/pomegranate_sapling.json
+++ b/src/main/resources/data/botanytrees/recipes/pamhc2trees/pomegranate_sapling.json
@@ -1,0 +1,57 @@
+{
+  "type": "botanypots:crop",
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "pamhc2trees"
+    },
+    {
+      "type": "forge:item_exists",
+      "item": "pamhc2trees:pomegranate_sapling"
+    }
+  ],
+  "seed": {
+    "item": "pamhc2trees:pomegranate_sapling"
+  },
+  "categories": [
+    "dirt"
+  ],
+  "growthTicks": 2400,
+  "display": {
+    "block": "pamhc2trees:pomegranate_sapling"
+  },
+  "results": [
+    {
+      "chance": 0.5,
+      "output": {
+        "item": "minecraft:jungle_log"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+      "chance": 0.1,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.05,
+      "output": {
+        "item": "minecraft:jungle_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.75,
+      "output": {
+        "item": "pamhc2trees:pomegranateitem"
+      },
+      "minRolls": 1,
+      "maxRolls": 4
+    }
+  ]
+}

--- a/src/main/resources/data/botanytrees/recipes/pamhc2trees/rambutan_sapling.json
+++ b/src/main/resources/data/botanytrees/recipes/pamhc2trees/rambutan_sapling.json
@@ -1,0 +1,57 @@
+{
+  "type": "botanypots:crop",
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "pamhc2trees"
+    },
+    {
+      "type": "forge:item_exists",
+      "item": "pamhc2trees:rambutan_sapling"
+    }
+  ],
+  "seed": {
+    "item": "pamhc2trees:rambutan_sapling"
+  },
+  "categories": [
+    "dirt"
+  ],
+  "growthTicks": 2400,
+  "display": {
+    "block": "pamhc2trees:rambutan_sapling"
+  },
+  "results": [
+    {
+      "chance": 0.5,
+      "output": {
+        "item": "minecraft:jungle_log"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+      "chance": 0.1,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.05,
+      "output": {
+        "item": "minecraft:jungle_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.75,
+      "output": {
+        "item": "pamhc2trees:rambutanitem"
+      },
+      "minRolls": 1,
+      "maxRolls": 4
+    }
+  ]
+}

--- a/src/main/resources/data/botanytrees/recipes/pamhc2trees/soursop_sapling.json
+++ b/src/main/resources/data/botanytrees/recipes/pamhc2trees/soursop_sapling.json
@@ -1,0 +1,57 @@
+{
+  "type": "botanypots:crop",
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "pamhc2trees"
+    },
+    {
+      "type": "forge:item_exists",
+      "item": "pamhc2trees:soursop_sapling"
+    }
+  ],
+  "seed": {
+    "item": "pamhc2trees:soursop_sapling"
+  },
+  "categories": [
+    "dirt"
+  ],
+  "growthTicks": 2400,
+  "display": {
+    "block": "pamhc2trees:soursop_sapling"
+  },
+  "results": [
+    {
+      "chance": 0.5,
+      "output": {
+        "item": "minecraft:oak_log"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+      "chance": 0.1,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.05,
+      "output": {
+        "item": "minecraft:oak_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.75,
+      "output": {
+        "item": "pamhc2trees:soursopitem"
+      },
+      "minRolls": 1,
+      "maxRolls": 4
+    }
+  ]
+}

--- a/src/main/resources/data/botanytrees/recipes/pamhc2trees/spiderweb_sapling.json
+++ b/src/main/resources/data/botanytrees/recipes/pamhc2trees/spiderweb_sapling.json
@@ -1,0 +1,57 @@
+{
+  "type": "botanypots:crop",
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "pamhc2trees"
+    },
+    {
+      "type": "forge:item_exists",
+      "item": "pamhc2trees:spiderweb_sapling"
+    }
+  ],
+  "seed": {
+    "item": "pamhc2trees:spiderweb_sapling"
+  },
+  "categories": [
+    "dirt"
+  ],
+  "growthTicks": 2400,
+  "display": {
+    "block": "pamhc2trees:spiderweb_sapling"
+  },
+  "results": [
+    {
+      "chance": 0.5,
+      "output": {
+        "item": "minecraft:oak_log"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+      "chance": 0.1,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.05,
+      "output": {
+        "item": "minecraft:oak_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.75,
+      "output": {
+        "item": "minecraft:string"
+      },
+      "minRolls": 1,
+      "maxRolls": 4
+    }
+  ]
+}

--- a/src/main/resources/data/botanytrees/recipes/pamhc2trees/starfruit_sapling.json
+++ b/src/main/resources/data/botanytrees/recipes/pamhc2trees/starfruit_sapling.json
@@ -1,0 +1,57 @@
+{
+  "type": "botanypots:crop",
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "pamhc2trees"
+    },
+    {
+      "type": "forge:item_exists",
+      "item": "pamhc2trees:starfruit_sapling"
+    }
+  ],
+  "seed": {
+    "item": "pamhc2trees:starfruit_sapling"
+  },
+  "categories": [
+    "dirt"
+  ],
+  "growthTicks": 2400,
+  "display": {
+    "block": "pamhc2trees:starfruit_sapling"
+  },
+  "results": [
+    {
+      "chance": 0.5,
+      "output": {
+        "item": "minecraft:jungle_log"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+      "chance": 0.1,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.05,
+      "output": {
+        "item": "minecraft:jungle_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.75,
+      "output": {
+        "item": "pamhc2trees:starfruititem"
+      },
+      "minRolls": 1,
+      "maxRolls": 4
+    }
+  ]
+}

--- a/src/main/resources/data/botanytrees/recipes/pamhc2trees/tamarind_sapling.json
+++ b/src/main/resources/data/botanytrees/recipes/pamhc2trees/tamarind_sapling.json
@@ -1,0 +1,57 @@
+{
+  "type": "botanypots:crop",
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "pamhc2trees"
+    },
+    {
+      "type": "forge:item_exists",
+      "item": "pamhc2trees:tamarind_sapling"
+    }
+  ],
+  "seed": {
+    "item": "pamhc2trees:tamarind_sapling"
+  },
+  "categories": [
+    "dirt"
+  ],
+  "growthTicks": 2400,
+  "display": {
+    "block": "pamhc2trees:tamarind_sapling"
+  },
+  "results": [
+    {
+      "chance": 0.5,
+      "output": {
+        "item": "minecraft:jungle_log"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+      "chance": 0.1,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.05,
+      "output": {
+        "item": "minecraft:jungle_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.75,
+      "output": {
+        "item": "pamhc2trees:tamarinditem"
+      },
+      "minRolls": 1,
+      "maxRolls": 4
+    }
+  ]
+}

--- a/src/main/resources/data/botanytrees/recipes/pamhc2trees/vanillabean_sapling.json
+++ b/src/main/resources/data/botanytrees/recipes/pamhc2trees/vanillabean_sapling.json
@@ -1,0 +1,57 @@
+{
+  "type": "botanypots:crop",
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "pamhc2trees"
+    },
+    {
+      "type": "forge:item_exists",
+      "item": "pamhc2trees:vanillabean_sapling"
+    }
+  ],
+  "seed": {
+    "item": "pamhc2trees:vanillabean_sapling"
+  },
+  "categories": [
+    "dirt"
+  ],
+  "growthTicks": 2400,
+  "display": {
+    "block": "pamhc2trees:vanillabean_sapling"
+  },
+  "results": [
+    {
+      "chance": 0.5,
+      "output": {
+        "item": "minecraft:jungle_log"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+      "chance": 0.1,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.05,
+      "output": {
+        "item": "minecraft:jungle_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.75,
+      "output": {
+        "item": "pamhc2trees:vanillabeanitem"
+      },
+      "minRolls": 1,
+      "maxRolls": 4
+    }
+  ]
+}

--- a/src/main/resources/data/botanytrees/recipes/pamhc2trees/walnut_sapling.json
+++ b/src/main/resources/data/botanytrees/recipes/pamhc2trees/walnut_sapling.json
@@ -1,0 +1,57 @@
+{
+  "type": "botanypots:crop",
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "pamhc2trees"
+    },
+    {
+      "type": "forge:item_exists",
+      "item": "pamhc2trees:walnut_sapling"
+    }
+  ],
+  "seed": {
+    "item": "pamhc2trees:walnut_sapling"
+  },
+  "categories": [
+    "dirt"
+  ],
+  "growthTicks": 2400,
+  "display": {
+    "block": "pamhc2trees:walnut_sapling"
+  },
+  "results": [
+    {
+      "chance": 0.5,
+      "output": {
+        "item": "minecraft:oak_log"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+      "chance": 0.1,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.05,
+      "output": {
+        "item": "minecraft:oak_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.75,
+      "output": {
+        "item": "pamhc2trees:walnutitem"
+      },
+      "minRolls": 1,
+      "maxRolls": 4
+    }
+  ]
+}


### PR DESCRIPTION
Performed a basic generation of the data files for the Pam's HC2 trees - only tweaked the paperbark, and cinnamon trees to have a vastly lower log drop rate. (since they only have one log at the top to support the leaves)
Cheers for a really nifty mod and the existing wide crop & tree support!