### PR TITLE
Fixed recipes for Autumnity maple trees

### DIFF
--- a/src/main/resources/data/botanytrees/recipes/autumnity/maple.json
+++ b/src/main/resources/data/botanytrees/recipes/autumnity/maple.json
@@ -4,10 +4,6 @@
         {
             "type": "forge:mod_loaded",
             "modid": "autumnity"
-        },
-        {
-            "type": "forge:item_exists",
-            "item": "autumnity:maple_sapling"
         }
     ],
     "seed": {

--- a/src/main/resources/data/botanytrees/recipes/autumnity/orange_maple.json
+++ b/src/main/resources/data/botanytrees/recipes/autumnity/orange_maple.json
@@ -4,10 +4,6 @@
         {
             "type": "forge:mod_loaded",
             "modid": "autumnity"
-        },
-        {
-            "type": "forge:item_exists",
-            "item": "autumnity:orange_maple_sapling"
         }
     ],
     "seed": {
@@ -24,7 +20,7 @@
         {
             "chance": 0.5,
             "output": {
-                "item": "autumnity:orange_maple_log"
+                "item": "autumnity:maple_log"
             },
             "minRolls": 1,
             "maxRolls": 1

--- a/src/main/resources/data/botanytrees/recipes/autumnity/red_maple.json
+++ b/src/main/resources/data/botanytrees/recipes/autumnity/red_maple.json
@@ -4,10 +4,6 @@
         {
             "type": "forge:mod_loaded",
             "modid": "autumnity"
-        },
-        {
-            "type": "forge:item_exists",
-            "item": "autumnity:red_maple_sapling"
         }
     ],
     "seed": {
@@ -24,7 +20,7 @@
         {
             "chance": 0.5,
             "output": {
-                "item": "autumnity:red_maple_log"
+                "item": "autumnity:maple_log"
             },
             "minRolls": 1,
             "maxRolls": 1

--- a/src/main/resources/data/botanytrees/recipes/autumnity/yellow_maple.json
+++ b/src/main/resources/data/botanytrees/recipes/autumnity/yellow_maple.json
@@ -4,10 +4,6 @@
         {
             "type": "forge:mod_loaded",
             "modid": "autumnity"
-        },
-        {
-            "type": "forge:item_exists",
-            "item": "autumnity:yellow_maple_sapling"
         }
     ],
     "seed": {
@@ -24,7 +20,7 @@
         {
             "chance": 0.5,
             "output": {
-                "item": "autumnity:yellow_maple_log"
+                "item": "autumnity:maple_log"
             },
             "minRolls": 1,
             "maxRolls": 1


### PR DESCRIPTION
The recipes for autumnity's red, orange and yellow maple trees contained an invalid item id, preventing the recipes from loading. I've also removed the redundant `item_exists` conditions, as those are always true when autumnity is loaded.