### PR TITLE
Overhaul BotanyTrees 1.18.2 Supports

### DIFF
--- a/Common/src/main/resources/data/botanytrees/recipes/allthemodium/ancient.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/allthemodium/ancient.json
@@ -1,0 +1,62 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "allthemodium:ancient_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "allthemodium:ancient_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "allthemodium:ancient_sapling"
+    },
+    "drops": [
+      {
+        "chance": 0.33,
+        "output": {
+          "item": "allthemodium:ancient_log_0"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+        
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.33,
+        "output": {
+          "item": "allthemodium:ancient_log_1"
+        },
+        "minRolls": 1,
+        "maxRolls": 2
+      },
+      {
+        "chance": 0.33,
+        "output": {
+          "item": "allthemodium:ancient_log_2"
+        },
+        "minRolls": 1,
+        "maxRolls": 2
+      },
+      {
+        "chance": 0.01,
+        "output": {
+          "item": "allthemodium:ancient_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/allthemodium/demonic.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/allthemodium/demonic.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "allthemodium:demonic_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "allthemodium:demonic_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "allthemodium:demonic_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "allthemodium:demonic_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "allthemodium:demonic_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/allthemodium/soul.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/allthemodium/soul.json
@@ -1,0 +1,69 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "allthemodium:soul_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "allthemodium:soul_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "allthemodium:soul_sapling"
+    },
+    "drops": [
+      {
+        "chance": 0.25,
+        "output": {
+          "item": "allthemodium:soul_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.25,
+        "output": {
+          "item": "allthemodium:soul_log_0"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+        "chance": 0.25,
+        "output": {
+          "item": "allthemodium:soul_log_1"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+        "chance": 0.25,
+        "output": {
+          "item": "allthemodium:soul_log_2"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "allthemodium:soul_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/allyoucaneat/hazel.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/allyoucaneat/hazel.json
@@ -1,0 +1,53 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "allyoucaneat:hazel_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "allyoucaneat:hazel_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "allyoucaneat:hazel_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "allyoucaneat:hazel_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+      },
+      {
+        "chance": 0.25,
+        "output": {
+          "item": "minecraft:stick"
+        },
+        "minRolls": 1,
+        "maxRolls": 2
+    },
+    {
+      "chance": 0.25,
+      "output": {
+        "item": "allyoucaneat:hazelnut"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "allyoucaneat:hazel_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/architectspalette/twisted.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/architectspalette/twisted.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "architects_palette:twisted_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "architects_palette:twisted_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "architects_palette:twisted_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "architects_palette:twisted_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.25,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "architects_palette:twisted_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/ars_nouveau/blazing_archwood.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/ars_nouveau/blazing_archwood.json
@@ -1,0 +1,37 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "ars_nouveau:red_archwood_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "ars_nouveau:red_archwood_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "ars_nouveau:red_archwood_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "ars_nouveau:red_archwood_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "ars_nouveau:red_archwood_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/ars_nouveau/cascading_archwood.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/ars_nouveau/cascading_archwood.json
@@ -1,0 +1,37 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "ars_nouveau:blue_archwood_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "ars_nouveau:blue_archwood_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "ars_nouveau:blue_archwood_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "ars_nouveau:blue_archwood_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "ars_nouveau:blue_archwood_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/ars_nouveau/flourishing_archwood.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/ars_nouveau/flourishing_archwood.json
@@ -1,0 +1,37 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "ars_nouveau:green_archwood_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "ars_nouveau:green_archwood_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "ars_nouveau:green_archwood_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "ars_nouveau:green_archwood_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "ars_nouveau:green_archwood_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/ars_nouveau/vexing_archwood.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/ars_nouveau/vexing_archwood.json
@@ -1,0 +1,37 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "ars_nouveau:purple_archwood_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "ars_nouveau:purple_archwood_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "ars_nouveau:purple_archwood_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "ars_nouveau:purple_archwood_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "ars_nouveau:purple_archwood_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/assemblylinemachines/chaosbark.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/assemblylinemachines/chaosbark.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "assemblylinemachines:chaosbark_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "assemblylinemachines:chaosbark_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "assemblylinemachines:chaosbark_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "assemblylinemachines:chaosbark_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.25,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "assemblylinemachines:chaosbark_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/assemblylinemachines/cocoa.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/assemblylinemachines/cocoa.json
@@ -1,0 +1,53 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "assemblylinemachines:cocoa_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "assemblylinemachines:cocoa_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "assemblylinemachines:cocoa_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:jungle_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.25,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.25,
+      "output": {
+        "item": "minecraft:cocoa_beans"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "assemblylinemachines:cocoa_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/atmospheric/aspen.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/atmospheric/aspen.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "atmospheric:aspen_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "atmospheric:aspen_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "atmospheric:aspen_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "atmospheric:aspen_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "atmospheric:aspen_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/atmospheric/grimwood.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/atmospheric/grimwood.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "atmospheric:grimwood_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "atmospheric:grimwood_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "atmospheric:grimwood_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "atmospheric:grimwood_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "atmospheric:grimwood_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/atmospheric/kousa.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/atmospheric/kousa.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "atmospheric:kousa_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "atmospheric:kousa_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "atmospheric:kousa_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "atmospheric:kousa_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "atmospheric:kousa_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/atmospheric/morado.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/atmospheric/morado.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "atmospheric:morado_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "atmospheric:morado_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "atmospheric:morado_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "atmospheric:morado_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "atmospheric:morado_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/atmospheric/rosewood.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/atmospheric/rosewood.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "atmospheric:rosewood_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "atmospheric:rosewood_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "atmospheric:rosewood_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "atmospheric:rosewood_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "atmospheric:rosewood_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/atmospheric/yucca.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/atmospheric/yucca.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "atmospheric:yucca_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "atmospheric:yucca_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "atmospheric:yucca_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "atmospheric:yucca_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "atmospheric:yucca_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/autumnity/maple.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/autumnity/maple.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "autumnity:maple_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "autumnity:maple_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "autumnity:maple_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "autumnity:maple_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "autumnity:maple_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/autumnity/orange_maple.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/autumnity/orange_maple.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "autumnity:orange_maple_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "autumnity:orange_maple_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "autumnity:orange_maple_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "autumnity:maple_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "autumnity:orange_maple_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/autumnity/red_maple.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/autumnity/red_maple.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "autumnity:red_maple_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "autumnity:red_maple_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "autumnity:red_maple_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "autumnity:maple_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "autumnity:red_maple_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/autumnity/yellow_maple.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/autumnity/yellow_maple.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "autumnity:yellow_maple_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "autumnity:yellow_maple_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "autumnity:yellow_maple_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "autumnity:maple_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "autumnity:yellow_maple_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/biomemakeover/ancient_oak.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/biomemakeover/ancient_oak.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "biomemakeover:ancient_oak_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "biomemakeover:ancient_oak_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "biomemakeover:ancient_oak_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "biomemakeover:ancient_oak_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "biomemakeover:ancient_oak_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/biomemakeover/blighted_balsa.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/biomemakeover/blighted_balsa.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "biomemakeover:blighted_balsa_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "biomemakeover:blighted_balsa_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "biomemakeover:blighted_balsa_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "biomemakeover:blighted_balsa_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "biomemakeover:blighted_balsa_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/biomemakeover/swamp_cypress.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/biomemakeover/swamp_cypress.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "biomemakeover:swamp_cypress_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "biomemakeover:swamp_cypress_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "biomemakeover:swamp_cypress_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "biomemakeover:swamp_cypress_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "biomemakeover:swamp_cypress_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/biomemakeover/willow.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/biomemakeover/willow.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "biomemakeover:willow_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "biomemakeover:willow_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "biomemakeover:willow_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "biomemakeover:willow_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "biomemakeover:willow_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/biomesoplenty/dead.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/biomesoplenty/dead.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "biomesoplenty:dead_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "biomesoplenty:dead_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "biomesoplenty:dead_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "biomesoplenty:dead_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "biomesoplenty:dead_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/biomesoplenty/fir.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/biomesoplenty/fir.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "biomesoplenty:fir_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "biomesoplenty:fir_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "biomesoplenty:fir_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "biomesoplenty:fir_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "biomesoplenty:fir_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/biomesoplenty/flowering_oak.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/biomesoplenty/flowering_oak.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "biomesoplenty:flowering_oak_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "biomesoplenty:flowering_oak_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "biomesoplenty:flowering_oak_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:oak_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "biomesoplenty:flowering_oak_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/biomesoplenty/hellbark.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/biomesoplenty/hellbark.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "biomesoplenty:hellbark_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "biomesoplenty:hellbark_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "biomesoplenty:hellbark_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "biomesoplenty:hellbark_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "biomesoplenty:hellbark_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/biomesoplenty/jacaranda.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/biomesoplenty/jacaranda.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "biomesoplenty:jacaranda_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "biomesoplenty:jacaranda_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "biomesoplenty:jacaranda_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "biomesoplenty:jacaranda_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "biomesoplenty:jacaranda_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/biomesoplenty/magic.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/biomesoplenty/magic.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "biomesoplenty:magic_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "biomesoplenty:magic_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "biomesoplenty:magic_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "biomesoplenty:magic_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "biomesoplenty:magic_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/biomesoplenty/mahogany.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/biomesoplenty/mahogany.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "biomesoplenty:mahogany_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "biomesoplenty:mahogany_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "biomesoplenty:mahogany_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "biomesoplenty:mahogany_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "biomesoplenty:mahogany_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/biomesoplenty/maple.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/biomesoplenty/maple.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "biomesoplenty:maple_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "biomesoplenty:maple_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "biomesoplenty:maple_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:oak_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "biomesoplenty:maple_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/biomesoplenty/orange_autumn.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/biomesoplenty/orange_autumn.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "biomesoplenty:orange_autumn_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "biomesoplenty:orange_autumn_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "biomesoplenty:orange_autumn_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:oak_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "biomesoplenty:orange_autumn_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/biomesoplenty/origin.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/biomesoplenty/origin.json
@@ -1,0 +1,46 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "biomesoplenty:origin_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "biomesoplenty:origin_sapling"
+    },
+    "categories": [
+      "dirt",
+      "origin_grass"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "biomesoplenty:origin_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:oak_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "biomesoplenty:origin_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/biomesoplenty/palm.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/biomesoplenty/palm.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "biomesoplenty:palm_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "biomesoplenty:palm_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "biomesoplenty:palm_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "biomesoplenty:palm_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "biomesoplenty:palm_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/biomesoplenty/pink_cherry.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/biomesoplenty/pink_cherry.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "biomesoplenty:pink_cherry_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "biomesoplenty:pink_cherry_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "biomesoplenty:pink_cherry_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "biomesoplenty:cherry_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "biomesoplenty:pink_cherry_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/biomesoplenty/rainbow_birch.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/biomesoplenty/rainbow_birch.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "biomesoplenty:rainbow_birch_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "biomesoplenty:rainbow_birch_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "biomesoplenty:rainbow_birch_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:birch_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "biomesoplenty:rainbow_birch_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/biomesoplenty/redwood.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/biomesoplenty/redwood.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "biomesoplenty:redwood_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "biomesoplenty:redwood_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "biomesoplenty:redwood_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "biomesoplenty:redwood_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "biomesoplenty:redwood_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/biomesoplenty/umbran.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/biomesoplenty/umbran.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "biomesoplenty:umbran_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "biomesoplenty:umbran_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "biomesoplenty:umbran_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "biomesoplenty:umbran_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "biomesoplenty:umbran_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/biomesoplenty/white_cherry.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/biomesoplenty/white_cherry.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "biomesoplenty:white_cherry_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "biomesoplenty:white_cherry_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "biomesoplenty:white_cherry_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "biomesoplenty:cherry_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "biomesoplenty:white_cherry_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/biomesoplenty/willow.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/biomesoplenty/willow.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "biomesoplenty:willow_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "biomesoplenty:willow_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "biomesoplenty:willow_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "biomesoplenty:willow_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "biomesoplenty:willow_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/biomesoplenty/yellow_autumn.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/biomesoplenty/yellow_autumn.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "biomesoplenty:yellow_autumn_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "biomesoplenty:yellow_autumn_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "biomesoplenty:yellow_autumn_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:birch_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "biomesoplenty:yellow_autumn_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/blueskies/bluebright.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/blueskies/bluebright.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "blue_skies:bluebright_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "blue_skies:bluebright_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "blue_skies:bluebright_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "blue_skies:bluebright_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "blue_skies:bluebright_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/blueskies/cherry.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/blueskies/cherry.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "blue_skies:cherry_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "blue_skies:cherry_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "blue_skies:cherry_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "blue_skies:cherry_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "blue_skies:cherry_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/blueskies/crescent_fruit.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/blueskies/crescent_fruit.json
@@ -1,0 +1,53 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "blue_skies:crescent_fruit_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "blue_skies:crescent_fruit_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "blue_skies:crescent_fruit_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "blue_skies:dusk_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.20,
+        "output": {
+          "item": "blue_skies:crescent_fruit"
+        },
+        "minRolls": 1,
+        "maxRolls": 2
+      },
+      {
+        "chance": 0.01,
+        "output": {
+          "item": "blue_skies:crescent_fruit_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/blueskies/dusk.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/blueskies/dusk.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "blue_skies:dusk_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "blue_skies:dusk_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "blue_skies:dusk_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "blue_skies:dusk_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "blue_skies:dusk_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/blueskies/frostbright.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/blueskies/frostbright.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "blue_skies:frostbright_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "blue_skies:frostbright_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "blue_skies:frostbright_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "blue_skies:frostbright_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "blue_skies:frostbright_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/blueskies/lunar.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/blueskies/lunar.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "blue_skies:lunar_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "blue_skies:lunar_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "blue_skies:lunar_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "blue_skies:lunar_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "blue_skies:lunar_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/blueskies/maple.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/blueskies/maple.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "blue_skies:maple_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "blue_skies:maple_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "blue_skies:maple_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "blue_skies:maple_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "blue_skies:maple_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/blueskies/starlit.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/blueskies/starlit.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "blue_skies:starlit_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "blue_skies:starlit_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "blue_skies:starlit_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "blue_skies:starlit_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "blue_skies:starlit_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/byg/araucaria.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/byg/araucaria.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "byg:araucaria_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "byg:araucaria_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "byg:araucaria_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "byg:pine_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "byg:araucaria_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/byg/aspen.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/byg/aspen.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "byg:aspen_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "byg:aspen_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "byg:aspen_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "byg:aspen_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "byg:aspen_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/byg/baobab.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/byg/baobab.json
@@ -1,0 +1,53 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "byg:baobab_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "byg:baobab_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "byg:baobab_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "byg:baobab_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.20,
+        "output": {
+          "item": "byg:baobab_fruit"
+        },
+        "minRolls": 1,
+        "maxRolls": 2
+      },
+      {
+        "chance": 0.01,
+        "output": {
+          "item": "byg:baobab_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/byg/blue_enchanted.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/byg/blue_enchanted.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "byg:blue_enchanted_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "byg:blue_enchanted_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "byg:blue_enchanted_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "byg:blue_enchanted_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "byg:blue_enchanted_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/byg/blue_spruce.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/byg/blue_spruce.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "byg:blue_spruce_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "byg:blue_spruce_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "byg:blue_spruce_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:spruce_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "byg:blue_spruce_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/byg/brown_birch.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/byg/brown_birch.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "byg:brown_birch_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "byg:brown_birch_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "byg:brown_birch_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:birch_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "byg:brown_birch_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/byg/brown_oak.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/byg/brown_oak.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "byg:brown_oak_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "byg:brown_oak_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "byg:brown_oak_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:oak_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "byg:brown_oak_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/byg/brown_zelkova.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/byg/brown_zelkova.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "byg:brown_zelkova_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "byg:brown_zelkova_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "byg:brown_zelkova_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "byg:zelkova_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "byg:brown_zelkova_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/byg/cika.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/byg/cika.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "byg:cika_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "byg:cika_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "byg:cika_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "byg:cika_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "byg:cika_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/byg/cypress.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/byg/cypress.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "byg:cypress_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "byg:cypress_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "byg:cypress_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "byg:cypress_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "byg:cypress_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/byg/ebony.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/byg/ebony.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "byg:ebony_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "byg:ebony_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "byg:ebony_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "byg:ebony_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "byg:ebony_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/byg/ether.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/byg/ether.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "byg:ether_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "byg:ether_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "byg:ether_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "byg:ether_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "byg:ether_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/byg/fir.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/byg/fir.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "byg:fir_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "byg:fir_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "byg:fir_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "byg:fir_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "byg:fir_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/byg/green_enchanted.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/byg/green_enchanted.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "byg:green_enchanted_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "byg:green_enchanted_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "byg:green_enchanted_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "byg:green_enchanted_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "byg:green_enchanted_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/byg/holly.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/byg/holly.json
@@ -1,0 +1,53 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "byg:holly_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "byg:holly_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "byg:holly_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "byg:holly_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "byg:holly_berries"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "byg:holly_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/byg/indigo_jacaranda.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/byg/indigo_jacaranda.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "byg:indigo_jacaranda_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "byg:indigo_jacaranda_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "byg:indigo_jacaranda_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "byg:jacaranda_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "byg:indigo_jacaranda_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/byg/jacaranda.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/byg/jacaranda.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "byg:jacaranda_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "byg:jacaranda_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "byg:jacaranda_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "byg:jacaranda_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "byg:jacaranda_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/byg/joshua.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/byg/joshua.json
@@ -1,0 +1,53 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "byg:joshua_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "byg:joshua_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "byg:joshua_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:oak_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.20,
+        "output": {
+          "item": "byg:joshua_fruit"
+        },
+        "minRolls": 1,
+        "maxRolls": 2
+      },
+      {
+        "chance": 0.01,
+        "output": {
+          "item": "byg:joshua_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/byg/lament.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/byg/lament.json
@@ -1,0 +1,53 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "byg:lament_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "byg:lament_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "byg:lament_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "byg:lament_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.10,
+      "output": {
+        "item": "minecraft:shroomlight"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "byg:lament_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/byg/mahogany.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/byg/mahogany.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "byg:mahogany_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "byg:mahogany_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "byg:mahogany_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "byg:mahogany_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "byg:mahogany_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/byg/mangrove.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/byg/mangrove.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "byg:mangrove_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "byg:mangrove_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "byg:mangrove_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "byg:mangrove_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "byg:mangrove_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/byg/maple.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/byg/maple.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "byg:maple_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "byg:maple_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "byg:maple_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "byg:maple_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "byg:maple_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/byg/nightshade.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/byg/nightshade.json
@@ -1,0 +1,53 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "byg:nightshade_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "byg:nightshade_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "byg:nightshade_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "byg:nightshade_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+        "chance": 0.15,
+        "output": {
+          "item": "byg:imbued_nightshade_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "byg:nightshade_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/byg/orange_birch.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/byg/orange_birch.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "byg:orange_birch_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "byg:orange_birch_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "byg:orange_birch_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:birch_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "byg:orange_birch_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/byg/orange_oak.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/byg/orange_oak.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "byg:orange_oak_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "byg:orange_oak_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "byg:orange_oak_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:oak_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "byg:orange_oak_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/byg/orange_spruce.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/byg/orange_spruce.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "byg:orange_spruce_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "byg:orange_spruce_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "byg:orange_spruce_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:spruce_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "byg:orange_spruce_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/byg/orchard.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/byg/orchard.json
@@ -1,0 +1,53 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "byg:orchard_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "byg:orchard_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "byg:orchard_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:oak_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:apple"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "byg:orchard_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/byg/palm.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/byg/palm.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "byg:palm_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "byg:palm_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "byg:palm_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "byg:palm_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "byg:palm_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/byg/palo_verde.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/byg/palo_verde.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "byg:palo_verde_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "byg:palo_verde_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "byg:palo_verde_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "byg:palo_verde_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "byg:palo_verde_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/byg/pine.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/byg/pine.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "byg:pine_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "byg:pine_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "byg:pine_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "byg:pine_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "byg:pine_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/byg/pink_cherry.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/byg/pink_cherry.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "byg:pink_cherry_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "byg:pink_cherry_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "byg:pink_cherry_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "byg:cherry_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "byg:pink_cherry_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/byg/rainbow_eucalyptus.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/byg/rainbow_eucalyptus.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "byg:rainbow_eucalyptus_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "byg:rainbow_eucalyptus_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "byg:rainbow_eucalyptus_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "byg:rainbow_eucalyptus_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "byg:rainbow_eucalyptus_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/byg/red_birch.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/byg/red_birch.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "byg:red_birch_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "byg:red_birch_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "byg:red_birch_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:birch_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "byg:red_birch_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/byg/red_maple.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/byg/red_maple.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "byg:red_maple_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "byg:red_maple_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "byg:red_maple_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "byg:maple_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "byg:red_maple_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/byg/red_oak.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/byg/red_oak.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "byg:red_oak_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "byg:red_oak_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "byg:red_oak_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:oak_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "byg:red_oak_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/byg/red_spruce.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/byg/red_spruce.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "byg:red_spruce_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "byg:red_spruce_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "byg:red_spruce_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:spruce_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "byg:red_spruce_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/byg/redwood.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/byg/redwood.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "byg:redwood_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "byg:redwood_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "byg:redwood_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "byg:redwood_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "byg:redwood_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/byg/silver_maple.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/byg/silver_maple.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "byg:silver_maple_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "byg:silver_maple_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "byg:silver_maple_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "byg:maple_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "byg:silver_maple_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/byg/skyris.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/byg/skyris.json
@@ -1,0 +1,53 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "byg:skyris_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "byg:skyris_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "byg:skyris_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "byg:skyris_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "byg:green_apple"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "byg:skyris_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/byg/white_cherry.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/byg/white_cherry.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "byg:white_cherry_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "byg:white_cherry_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "byg:white_cherry_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "byg:cherry_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "byg:white_cherry_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/byg/willow.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/byg/willow.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "byg:willow_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "byg:willow_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "byg:willow_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "byg:willow_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "byg:willow_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/byg/witch_hazel.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/byg/witch_hazel.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "byg:witch_hazel_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "byg:witch_hazel_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "byg:witch_hazel_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "byg:witch_hazel_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "byg:witch_hazel_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/byg/withering_oak.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/byg/withering_oak.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "byg:withering_oak_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "byg:withering_oak_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "byg:withering_oak_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "byg:withering_oak_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "byg:withering_oak_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/byg/yellow_birch.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/byg/yellow_birch.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "byg:yellow_birch_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "byg:yellow_birch_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "byg:yellow_birch_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:birch_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "byg:yellow_birch_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/byg/yellow_spruce.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/byg/yellow_spruce.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "byg:yellow_spruce_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "byg:yellow_spruce_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "byg:yellow_spruce_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:spruce_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "byg:yellow_spruce_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/byg/zelkova.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/byg/zelkova.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "byg:zelkova_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "byg:zelkova_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "byg:zelkova_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "byg:zelkova_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "byg:zelkova_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/croptopia/almond.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/croptopia/almond.json
@@ -1,0 +1,53 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "croptopia:almond_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "croptopia:almond_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "croptopia:almond_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:dark_oak_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "croptopia:almond"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "croptopia:almond_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/croptopia/apple.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/croptopia/apple.json
@@ -1,0 +1,53 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "croptopia:apple_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "croptopia:apple_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "croptopia:apple_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:oak_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:apple"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "croptopia:apple_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/croptopia/apricot.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/croptopia/apricot.json
@@ -1,0 +1,53 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "croptopia:apricot_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "croptopia:apricot_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "croptopia:apricot_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:oak_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "croptopia:apricot"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "croptopia:apricot_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/croptopia/avocado.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/croptopia/avocado.json
@@ -1,0 +1,53 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "croptopia:avocado_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "croptopia:avocado_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "croptopia:avocado_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:spruce_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "croptopia:avocado"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "croptopia:avocado_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/croptopia/banana.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/croptopia/banana.json
@@ -1,0 +1,53 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "croptopia:banana_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "croptopia:banana_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "croptopia:banana_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:jungle_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "croptopia:banana"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "croptopia:banana_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/croptopia/cashew.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/croptopia/cashew.json
@@ -1,0 +1,53 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "croptopia:cashew_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "croptopia:cashew_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "croptopia:cashew_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:dark_oak_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "croptopia:cashew"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "croptopia:cashew_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/croptopia/cherry.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/croptopia/cherry.json
@@ -1,0 +1,53 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "croptopia:cherry_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "croptopia:cherry_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "croptopia:cherry_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:oak_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "croptopia:cherry"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "croptopia:cherry_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/croptopia/cinnamon.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/croptopia/cinnamon.json
@@ -1,0 +1,53 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "croptopia:cinnamon_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "croptopia:cinnamon_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "croptopia:cinnamon_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "croptopia:cinnamon_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "croptopia:cinnamon"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "croptopia:cinnamon_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/croptopia/coconut.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/croptopia/coconut.json
@@ -1,0 +1,53 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "croptopia:coconut_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "croptopia:coconut_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "croptopia:coconut_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:jungle_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "croptopia:coconut"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "croptopia:coconut_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/croptopia/date.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/croptopia/date.json
@@ -1,0 +1,53 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "croptopia:date_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "croptopia:date_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "croptopia:date_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:jungle_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "croptopia:date"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "croptopia:date_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/croptopia/dragonfruit.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/croptopia/dragonfruit.json
@@ -1,0 +1,53 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "croptopia:dragonfruit_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "croptopia:dragonfruit_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "croptopia:dragonfruit_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:jungle_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "croptopia:dragonfruit"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "croptopia:dragonfruit_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/croptopia/fig.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/croptopia/fig.json
@@ -1,0 +1,53 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "croptopia:fig_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "croptopia:fig_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "croptopia:fig_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:jungle_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "croptopia:fig"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "croptopia:fig_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/croptopia/grapefruit.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/croptopia/grapefruit.json
@@ -1,0 +1,53 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "croptopia:grapefruit_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "croptopia:grapefruit_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "croptopia:grapefruit_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:jungle_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "croptopia:grapefruit"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "croptopia:grapefruit_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/croptopia/kumquat.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/croptopia/kumquat.json
@@ -1,0 +1,53 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "croptopia:kumquat_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "croptopia:kumquat_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "croptopia:kumquat_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:jungle_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "croptopia:kumquat"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "croptopia:kumquat_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/croptopia/lemon.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/croptopia/lemon.json
@@ -1,0 +1,53 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "croptopia:lemon_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "croptopia:lemon_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "croptopia:lemon_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:oak_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "croptopia:lemon"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "croptopia:lemon_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/croptopia/lime.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/croptopia/lime.json
@@ -1,0 +1,53 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "croptopia:lime_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "croptopia:lime_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "croptopia:lime_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:oak_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "croptopia:lime"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "croptopia:lime_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/croptopia/mango.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/croptopia/mango.json
@@ -1,0 +1,53 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "croptopia:mango_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "croptopia:mango_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "croptopia:mango_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:jungle_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "croptopia:mango"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "croptopia:mango_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/croptopia/nectarine.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/croptopia/nectarine.json
@@ -1,0 +1,53 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "croptopia:nectarine_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "croptopia:nectarine_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "croptopia:nectarine_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:oak_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "croptopia:nectarine"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "croptopia:nectarine_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/croptopia/nutmeg.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/croptopia/nutmeg.json
@@ -1,0 +1,53 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "croptopia:nutmeg_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "croptopia:nutmeg_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "croptopia:nutmeg_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:jungle_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "croptopia:nutmeg"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "croptopia:nutmeg_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/croptopia/orange.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/croptopia/orange.json
@@ -1,0 +1,53 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "croptopia:orange_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "croptopia:orange_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "croptopia:orange_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:oak_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "croptopia:orange"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "croptopia:orange_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/croptopia/peach.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/croptopia/peach.json
@@ -1,0 +1,53 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "croptopia:peach_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "croptopia:peach_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "croptopia:peach_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:oak_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "croptopia:peach"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "croptopia:peach_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/croptopia/pear.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/croptopia/pear.json
@@ -1,0 +1,53 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "croptopia:pear_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "croptopia:pear_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "croptopia:pear_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:oak_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "croptopia:pear"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "croptopia:pear_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/croptopia/pecan.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/croptopia/pecan.json
@@ -1,0 +1,53 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "croptopia:pecan_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "croptopia:pecan_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "croptopia:pecan_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:dark_oak_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "croptopia:pecan"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "croptopia:pecan_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/croptopia/persimmon.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/croptopia/persimmon.json
@@ -1,0 +1,53 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "croptopia:persimmon_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "croptopia:persimmon_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "croptopia:persimmon_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:jungle_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "croptopia:persimmon"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "croptopia:persimmon_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/croptopia/plum.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/croptopia/plum.json
@@ -1,0 +1,53 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "croptopia:plum_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "croptopia:plum_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "croptopia:plum_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:jungle_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "croptopia:plum"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "croptopia:plum_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/croptopia/starfruit.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/croptopia/starfruit.json
@@ -1,0 +1,53 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "croptopia:starfruit_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "croptopia:starfruit_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "croptopia:starfruit_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:oak_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "croptopia:starfruit"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "croptopia:starfruit_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/croptopia/walnut.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/croptopia/walnut.json
@@ -1,0 +1,53 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "croptopia:walnut_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "croptopia:walnut_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "croptopia:walnut_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:dark_oak_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "croptopia:walnut"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "croptopia:walnut_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/ecologics/walnut.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/ecologics/walnut.json
@@ -1,0 +1,53 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "ecologics:walnut_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "ecologics:walnut_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "ecologics:walnut_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "ecologics:walnut_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+      },
+      {
+        "chance": 0.25,
+        "output": {
+          "item": "minecraft:stick"
+        },
+        "minRolls": 1,
+        "maxRolls": 2
+    },
+    {
+      "chance": 0.25,
+      "output": {
+        "item": "ecologics:walnut"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+      },
+      {
+        "chance": 0.15,
+        "output": {
+          "item": "ecologics:walnut_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/enhancedfarming/apple.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/enhancedfarming/apple.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "enhancedfarming:apple_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "enhancedfarming:apple_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "enhancedfarming:apple_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:oak_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+        "chance": 0.20,
+        "output": {
+          "item": "minecraft:apple"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+        "chance": 0.20,
+        "output": {
+          "item": "enhancedfarming:apple_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/enhancedfarming/banana.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/enhancedfarming/banana.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "enhancedfarming:banana_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "enhancedfarming:banana_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "enhancedfarming:banana_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:jungle_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+        "chance": 0.20,
+        "output": {
+          "item": "enhancedfarming:banana"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+        "chance": 0.20,
+        "output": {
+          "item": "enhancedfarming:banana_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/enhancedfarming/cherry.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/enhancedfarming/cherry.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "enhancedfarming:cherry_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "enhancedfarming:cherry_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "enhancedfarming:cherry_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:oak_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+        "chance": 0.20,
+        "output": {
+          "item": "enhancedfarming:cherry"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+        "chance": 0.20,
+        "output": {
+          "item": "enhancedfarming:cherry_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/enhancedfarming/lemon.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/enhancedfarming/lemon.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "enhancedfarming:lemon_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "enhancedfarming:lemon_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "enhancedfarming:lemon_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:oak_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+        "chance": 0.20,
+        "output": {
+          "item": "enhancedfarming:lemon"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+        "chance": 0.20,
+        "output": {
+          "item": "enhancedfarming:lemon_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/enhancedfarming/olive.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/enhancedfarming/olive.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "enhancedfarming:olive_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "enhancedfarming:olive_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "enhancedfarming:olive_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:acacia_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+        "chance": 0.20,
+        "output": {
+          "item": "enhancedfarming:olive"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+        "chance": 0.20,
+        "output": {
+          "item": "enhancedfarming:olive_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/enhancedfarming/orange.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/enhancedfarming/orange.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "enhancedfarming:orange_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "enhancedfarming:orange_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "enhancedfarming:orange_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:oak_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+        "chance": 0.20,
+        "output": {
+          "item": "enhancedfarming:orange"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+        "chance": 0.20,
+        "output": {
+          "item": "enhancedfarming:orange_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/enhancedfarming/pear.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/enhancedfarming/pear.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "enhancedfarming:pear_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "enhancedfarming:pear_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "enhancedfarming:pear_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:oak_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+        "chance": 0.20,
+        "output": {
+          "item": "enhancedfarming:pear"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+        "chance": 0.20,
+        "output": {
+          "item": "enhancedfarming:pear_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/environmental/blue_wisteria.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/environmental/blue_wisteria.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "environmental:blue_wisteria_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "environmental:blue_wisteria_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "environmental:blue_wisteria_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "environmental:wisteria_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "environmental:blue_wisteria_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/environmental/cherry.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/environmental/cherry.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "environmental:cherry_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "environmental:cherry_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "environmental:cherry_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "environmental:cherry_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "environmental:cherry_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/environmental/pink_wisteria.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/environmental/pink_wisteria.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "environmental:pink_wisteria_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "environmental:pink_wisteria_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "environmental:pink_wisteria_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "environmental:wisteria_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "environmental:pink_wisteria_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/environmental/purple_wisteria.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/environmental/purple_wisteria.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "environmental:purple_wisteria_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "environmental:purple_wisteria_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "environmental:purple_wisteria_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "environmental:wisteria_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "environmental:purple_wisteria_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/environmental/white_wisteria.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/environmental/white_wisteria.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "environmental:white_wisteria_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "environmental:white_wisteria_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "environmental:white_wisteria_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "environmental:wisteria_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "environmental:white_wisteria_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/environmental/willow.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/environmental/willow.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "environmental:willow_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "environmental:willow_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "environmental:willow_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "environmental:willow_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "environmental:willow_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/evilcraft/undead.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/evilcraft/undead.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "evilcraft:undead_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "evilcraft:undead_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "evilcraft:undead_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "evilcraft:undead_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.25,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "evilcraft:undead_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/forbiddenarcanus/cherrywood.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/forbiddenarcanus/cherrywood.json
@@ -1,0 +1,69 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "forbidden_arcanus:cherrywood_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "forbidden_arcanus:cherrywood_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "forbidden_arcanus:cherrywood_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "forbidden_arcanus:cherrywood_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+      },
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "forbidden_arcanus:thin_cherrywood_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+      },
+      {
+        "chance": 0.25,
+        "output": {
+          "item": "minecraft:stick"
+        },
+        "minRolls": 1,
+        "maxRolls": 2
+    },
+    {
+        "chance": 0.10,
+        "output": {
+          "item": "forbidden_arcanus:cherry_flower_vines"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+      },
+      {
+      "chance": 0.25,
+      "output": {
+        "item": "forbidden_arcanus:cherrywood_leaf_carpet"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "forbidden_arcanus:cherrywood_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/forbiddenarcanus/growing_edelwood.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/forbiddenarcanus/growing_edelwood.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "forbidden_arcanus:growing_edelwood"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "forbidden_arcanus:growing_edelwood"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "forbidden_arcanus:growing_edelwood"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "forbidden_arcanus:edelwood_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+      },
+      {
+        "chance": 0.25,
+        "output": {
+          "item": "forbidden_arcanus:edelwood_branch"
+        },
+        "minRolls": 1,
+        "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "forbidden_arcanus:growing_edelwood"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/forbiddenarcanus/mysterywood.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/forbiddenarcanus/mysterywood.json
@@ -1,0 +1,53 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "forbidden_arcanus:mysterywood_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "forbidden_arcanus:mysterywood_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "forbidden_arcanus:mysterywood_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "forbidden_arcanus:mysterywood_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+      },
+      {
+        "chance": 0.25,
+        "output": {
+          "item": "minecraft:stick"
+        },
+        "minRolls": 1,
+        "maxRolls": 2
+    },
+    {
+      "chance": 0.005,
+      "output": {
+        "item": "minecraft:gold_nugget"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "forbidden_arcanus:mysterywood_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/fruittrees/apple.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/fruittrees/apple.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "fruittrees:apple_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "fruittrees:apple_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "fruittrees:apple_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:oak_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.10,
+      "output": {
+        "item": "minecraft:apple"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "fruittrees:apple_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/fruittrees/cherry.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/fruittrees/cherry.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "fruittrees:cherry_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "fruittrees:cherry_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "fruittrees:cherry_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "fruittrees:cherry_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.10,
+      "output": {
+        "item": "fruittrees:cherry"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "fruittrees:cherry_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/fruittrees/citron.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/fruittrees/citron.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "fruittrees:citron_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "fruittrees:citron_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "fruittrees:citron_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "fruittrees:citrus_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.10,
+      "output": {
+        "item": "fruittrees:citron"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "fruittrees:citron_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/fruittrees/grapefruit.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/fruittrees/grapefruit.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "fruittrees:grapefruit_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "fruittrees:grapefruit_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "fruittrees:grapefruit_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "fruittrees:citrus_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.10,
+      "output": {
+        "item": "fruittrees:grapefruit"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "fruittrees:grapefruit_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/fruittrees/lemon.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/fruittrees/lemon.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "fruittrees:lemon_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "fruittrees:lemon_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "fruittrees:lemon_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "fruittrees:citrus_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.10,
+      "output": {
+        "item": "fruittrees:lemon"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "fruittrees:lemon_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/fruittrees/lime.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/fruittrees/lime.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "fruittrees:lime_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "fruittrees:lime_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "fruittrees:lime_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "fruittrees:citrus_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.10,
+      "output": {
+        "item": "fruittrees:lime"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "fruittrees:lime_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/fruittrees/mandarin.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/fruittrees/mandarin.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "fruittrees:mandarin_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "fruittrees:mandarin_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "fruittrees:mandarin_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "fruittrees:citrus_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.10,
+      "output": {
+        "item": "fruittrees:mandarin"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "fruittrees:mandarin_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/fruittrees/orange.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/fruittrees/orange.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "fruittrees:orange_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "fruittrees:orange_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "fruittrees:orange_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "fruittrees:citrus_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.10,
+      "output": {
+        "item": "fruittrees:orange"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "fruittrees:orange_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/fruittrees/pomelo.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/fruittrees/pomelo.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "fruittrees:pomelo_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "fruittrees:pomelo_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "fruittrees:pomelo_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "fruittrees:citrus_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.10,
+      "output": {
+        "item": "fruittrees:pomelo"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "fruittrees:pomelo_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/fruittrees/redlove.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/fruittrees/redlove.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "fruittrees:redlove_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "fruittrees:redlove_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "fruittrees:redlove_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "fruittrees:cherry_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.10,
+      "output": {
+        "item": "fruittrees:redlove"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "fruittrees:redlove_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/industrialreborn/rubber.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/industrialreborn/rubber.json
@@ -1,0 +1,53 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "indreb:rubber_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "indreb:rubber_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "indreb:rubber_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "indreb:rubber_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+      },
+      {
+        "chance": 0.25,
+        "output": {
+          "item": "minecraft:stick"
+        },
+        "minRolls": 1,
+        "maxRolls": 2
+    },
+    {
+      "chance": 0.25,
+      "output": {
+        "item": "indreb:rubber"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "indreb:rubber_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/integrateddynamics/menril.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/integrateddynamics/menril.json
@@ -1,0 +1,53 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "integrateddynamics:menril_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "integrateddynamics:menril_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "integrateddynamics:menril_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "integrateddynamics:menril_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+      },
+      {
+        "chance": 0.25,
+        "output": {
+          "item": "minecraft:stick"
+        },
+        "minRolls": 1,
+        "maxRolls": 2
+    },
+    {
+      "chance": 0.25,
+      "output": {
+        "item": "integrateddynamics:menril_berries"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "integrateddynamics:menril_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/malum/runewood.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/malum/runewood.json
@@ -1,0 +1,53 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "malum:runewood_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "malum:runewood_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "malum:runewood_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "malum:runewood_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+      },
+      {
+        "chance": 0.25,
+        "output": {
+          "item": "minecraft:stick"
+        },
+        "minRolls": 1,
+        "maxRolls": 2
+    },
+    {
+      "chance": 0.10,
+      "output": {
+        "item": "malum:exposed_runewood_log"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "malum:runewood_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/malum/soulwood.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/malum/soulwood.json
@@ -1,0 +1,53 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "malum:soulwood_growth"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "malum:soulwood_growth"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "malum:soulwood_growth"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "malum:soulwood_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+      },
+      {
+        "chance": 0.25,
+        "output": {
+          "item": "minecraft:stick"
+        },
+        "minRolls": 1,
+        "maxRolls": 2
+    },
+    {
+      "chance": 0.10,
+      "output": {
+        "item": "malum:exposed_soulwood_log"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "malum:soulwood_growth"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/moshizmod/apple.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/moshizmod/apple.json
@@ -1,0 +1,53 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "ms:nature/apple_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "ms:nature/apple_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "ms:nature/apple_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:oak_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.25,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.25,
+      "output": {
+        "item": "minecraft:apple"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "ms:nature/apple_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/moshizmod/cherry.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/moshizmod/cherry.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "ms:nature/cherrysapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "ms:nature/cherrysapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "ms:nature/cherrysapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "ms:nature/cherrylog"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.25,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "ms:nature/cherrysapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/moshizmod/glowood.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/moshizmod/glowood.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "ms:nature/glowsapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "ms:nature/glowsapling"
+    },
+    "categories": [
+      "netherrack"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "ms:nature/glowsapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "ms:nature/glowoodlog"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.25,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "ms:nature/glowsapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/moshizmod/hellwood.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/moshizmod/hellwood.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "ms:nature/hellwood_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "ms:nature/hellwood_sapling"
+    },
+    "categories": [
+      "netherrack"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "ms:nature/hellwood_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "ms:nature/hellwood_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.25,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "ms:nature/hellwood_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/moshizmod/maple.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/moshizmod/maple.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "ms:nature/maplesapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "ms:nature/maplesapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "ms:nature/maplesapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "ms:nature/maplelog"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.25,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "ms:nature/maplesapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/moshizmod/silverbell.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/moshizmod/silverbell.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "ms:nature/silverbell_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "ms:nature/silverbell_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "ms:nature/silverbell_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "ms:nature/silverbell_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.25,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "ms:nature/silverbell_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/moshizmod/tigerwood.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/moshizmod/tigerwood.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "ms:nature/tigerwoodsapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "ms:nature/tigerwoodsapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "ms:nature/tigerwoodsapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "ms:nature/tigerwoodlog"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.25,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "ms:nature/tigerwoodsapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/moshizmod/willow.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/moshizmod/willow.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "ms:nature/willowsapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "ms:nature/willowsapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "ms:nature/willowsapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "ms:nature/willowlog"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.25,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "ms:nature/willowsapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/myrtrees/rubberwood.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/myrtrees/rubberwood.json
@@ -1,0 +1,53 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "myrtrees:rubberwood_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "myrtrees:rubberwood_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "myrtrees:rubberwood_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "myrtrees:rubberwood_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+      },
+      {
+        "chance": 0.25,
+        "output": {
+          "item": "minecraft:stick"
+        },
+        "minRolls": 1,
+        "maxRolls": 2
+    },
+    {
+      "chance": 0.25,
+      "output": {
+        "item": "minecraft:apple"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "myrtrees:rubberwood_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/naturesaura/ancient.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/naturesaura/ancient.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "naturesaura:ancient_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "naturesaura:ancient_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "naturesaura:ancient_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "naturesaura:ancient_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.25,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "naturesaura:ancient_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/almond_sapling.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/almond_sapling.json
@@ -1,0 +1,61 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "pamhc2trees:almond_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "pamhc2trees:almond_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "pamhc2trees:almond_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:jungle_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "pamhc2trees:almonditem"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.01,
+      "output": {
+        "item": "minecraft:jungle_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+        "chance": 0.001,
+        "output": {
+          "item": "pamhc2trees:almond_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/apple_sapling.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/apple_sapling.json
@@ -1,0 +1,61 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "pamhc2trees:apple_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "pamhc2trees:apple_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "pamhc2trees:apple_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:oak_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:apple"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.01,
+      "output": {
+        "item": "minecraft:oak_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+        "chance": 0.001,
+        "output": {
+          "item": "pamhc2trees:apple_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/apricot_sapling.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/apricot_sapling.json
@@ -1,0 +1,61 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "pamhc2trees:apricot_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "pamhc2trees:apricot_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "pamhc2trees:apricot_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:jungle_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "pamhc2trees:apricotitem"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.01,
+      "output": {
+        "item": "minecraft:jungle_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+        "chance": 0.001,
+        "output": {
+          "item": "pamhc2trees:apricot_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/avocado_sapling.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/avocado_sapling.json
@@ -1,0 +1,61 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "pamhc2trees:avocado_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "pamhc2trees:avocado_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "pamhc2trees:avocado_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:jungle_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "pamhc2trees:avocadoitem"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.01,
+      "output": {
+        "item": "minecraft:jungle_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+        "chance": 0.001,
+        "output": {
+          "item": "pamhc2trees:avocado_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/banana_sapling.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/banana_sapling.json
@@ -1,0 +1,61 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "pamhc2trees:banana_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "pamhc2trees:banana_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "pamhc2trees:banana_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:jungle_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "pamhc2trees:bananaitem"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.01,
+      "output": {
+        "item": "minecraft:jungle_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+        "chance": 0.001,
+        "output": {
+          "item": "pamhc2trees:banana_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/breadfruit_sapling.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/breadfruit_sapling.json
@@ -1,0 +1,61 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "pamhc2trees:breadfruit_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "pamhc2trees:breadfruit_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "pamhc2trees:breadfruit_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:jungle_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "pamhc2trees:breadfruititem"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.01,
+      "output": {
+        "item": "minecraft:jungle_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+        "chance": 0.001,
+        "output": {
+          "item": "pamhc2trees:breadfruit_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/candlenut_sapling.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/candlenut_sapling.json
@@ -1,0 +1,61 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "pamhc2trees:candlenut_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "pamhc2trees:candlenut_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "pamhc2trees:candlenut_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:oak_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "pamhc2trees:candlenutitem"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.01,
+      "output": {
+        "item": "minecraft:oak_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+        "chance": 0.001,
+        "output": {
+          "item": "pamhc2trees:candlenut_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/cashew_sapling.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/cashew_sapling.json
@@ -1,0 +1,61 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "pamhc2trees:cashew_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "pamhc2trees:cashew_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "pamhc2trees:cashew_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:jungle_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "pamhc2trees:cashewitem"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.01,
+      "output": {
+        "item": "minecraft:jungle_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+        "chance": 0.001,
+        "output": {
+          "item": "pamhc2trees:cashew_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/cherry_sapling.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/cherry_sapling.json
@@ -1,0 +1,61 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "pamhc2trees:cherry_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "pamhc2trees:cherry_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "pamhc2trees:cherry_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:oak_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "pamhc2trees:cherryitem"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.01,
+      "output": {
+        "item": "minecraft:oak_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+        "chance": 0.001,
+        "output": {
+          "item": "pamhc2trees:cherry_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/chestnut_sapling.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/chestnut_sapling.json
@@ -1,0 +1,61 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "pamhc2trees:chestnut_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "pamhc2trees:chestnut_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "pamhc2trees:chestnut_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:oak_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "pamhc2trees:chestnutitem"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.01,
+      "output": {
+        "item": "minecraft:oak_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+        "chance": 0.001,
+        "output": {
+          "item": "pamhc2trees:chestnut_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/cinnamon_sapling.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/cinnamon_sapling.json
@@ -1,0 +1,69 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "pamhc2trees:cinnamon_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "pamhc2trees:cinnamon_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "pamhc2trees:cinnamon_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:jungle_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+        "chance": 0.20,
+        "output": {
+          "item": "pamhc2trees:pamcinnamon"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "pamhc2trees:cinnamonitem"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.01,
+      "output": {
+        "item": "minecraft:jungle_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+        "chance": 0.001,
+        "output": {
+          "item": "pamhc2trees:cinnamon_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/coconut_sapling.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/coconut_sapling.json
@@ -1,0 +1,61 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "pamhc2trees:coconut_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "pamhc2trees:coconut_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "pamhc2trees:coconut_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:jungle_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "pamhc2trees:coconutitem"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.01,
+      "output": {
+        "item": "minecraft:jungle_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+        "chance": 0.001,
+        "output": {
+          "item": "pamhc2trees:coconut_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/date_sapling.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/date_sapling.json
@@ -1,0 +1,61 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "pamhc2trees:date_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "pamhc2trees:date_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "pamhc2trees:date_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:jungle_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "pamhc2trees:dateitem"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.01,
+      "output": {
+        "item": "minecraft:jungle_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+        "chance": 0.001,
+        "output": {
+          "item": "pamhc2trees:date_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/dragonfruit_sapling.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/dragonfruit_sapling.json
@@ -1,0 +1,61 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "pamhc2trees:dragonfruit_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "pamhc2trees:dragonfruit_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "pamhc2trees:dragonfruit_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:jungle_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "pamhc2trees:dragonfruititem"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.01,
+      "output": {
+        "item": "minecraft:jungle_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+        "chance": 0.001,
+        "output": {
+          "item": "pamhc2trees:dragonfruit_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/durian_sapling.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/durian_sapling.json
@@ -1,0 +1,61 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "pamhc2trees:durian_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "pamhc2trees:durian_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "pamhc2trees:durian_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:jungle_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "pamhc2trees:durianitem"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.01,
+      "output": {
+        "item": "minecraft:jungle_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+        "chance": 0.001,
+        "output": {
+          "item": "pamhc2trees:durian_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/fig_sapling.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/fig_sapling.json
@@ -1,0 +1,61 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "pamhc2trees:fig_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "pamhc2trees:fig_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "pamhc2trees:fig_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:jungle_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "pamhc2trees:figitem"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.01,
+      "output": {
+        "item": "minecraft:jungle_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+        "chance": 0.001,
+        "output": {
+          "item": "pamhc2trees:fig_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/gooseberry_sapling.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/gooseberry_sapling.json
@@ -1,0 +1,61 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "pamhc2trees:gooseberry_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "pamhc2trees:gooseberry_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "pamhc2trees:gooseberry_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:oak_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "pamhc2trees:gooseberryitem"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.01,
+      "output": {
+        "item": "minecraft:oak_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+        "chance": 0.001,
+        "output": {
+          "item": "pamhc2trees:gooseberry_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/grapefruit_sapling.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/grapefruit_sapling.json
@@ -1,0 +1,61 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "pamhc2trees:grapefruit_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "pamhc2trees:grapefruit_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "pamhc2trees:grapefruit_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:jungle_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "pamhc2trees:grapefruititem"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.01,
+      "output": {
+        "item": "minecraft:jungle_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+        "chance": 0.001,
+        "output": {
+          "item": "pamhc2trees:grapefruit_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/guava_sapling.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/guava_sapling.json
@@ -1,0 +1,61 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "pamhc2trees:guava_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "pamhc2trees:guava_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "pamhc2trees:guava_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:jungle_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "pamhc2trees:guavaitem"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.01,
+      "output": {
+        "item": "minecraft:jungle_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+        "chance": 0.001,
+        "output": {
+          "item": "pamhc2trees:guava_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/hazelnut_sapling.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/hazelnut_sapling.json
@@ -1,0 +1,61 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "pamhc2trees:hazelnut_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "pamhc2trees:hazelnut_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "pamhc2trees:hazelnut_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:oak_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "pamhc2trees:hazelnutitem"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.01,
+      "output": {
+        "item": "minecraft:oak_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+        "chance": 0.001,
+        "output": {
+          "item": "pamhc2trees:hazelnut_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/jackfruit_sapling.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/jackfruit_sapling.json
@@ -1,0 +1,61 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "pamhc2trees:jackfruit_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "pamhc2trees:jackfruit_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "pamhc2trees:jackfruit_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:jungle_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "pamhc2trees:jackfruititem"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.01,
+      "output": {
+        "item": "minecraft:jungle_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+        "chance": 0.001,
+        "output": {
+          "item": "pamhc2trees:jackfruit_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/lemon_sapling.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/lemon_sapling.json
@@ -1,0 +1,61 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "pamhc2trees:lemon_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "pamhc2trees:lemon_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "pamhc2trees:lemon_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:oak_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "pamhc2trees:lemonitem"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.01,
+      "output": {
+        "item": "minecraft:oak_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+        "chance": 0.001,
+        "output": {
+          "item": "pamhc2trees:lemon_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/lime_sapling.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/lime_sapling.json
@@ -1,0 +1,61 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "pamhc2trees:lime_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "pamhc2trees:lime_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "pamhc2trees:lime_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:jungle_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "pamhc2trees:limeitem"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.01,
+      "output": {
+        "item": "minecraft:jungle_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+        "chance": 0.001,
+        "output": {
+          "item": "pamhc2trees:lime_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/lychee_sapling.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/lychee_sapling.json
@@ -1,0 +1,61 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "pamhc2trees:lychee_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "pamhc2trees:lychee_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "pamhc2trees:lychee_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:jungle_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "pamhc2trees:lycheeitem"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.01,
+      "output": {
+        "item": "minecraft:jungle_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+        "chance": 0.001,
+        "output": {
+          "item": "pamhc2trees:lychee_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/mango_sapling.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/mango_sapling.json
@@ -1,0 +1,61 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "pamhc2trees:mango_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "pamhc2trees:mango_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "pamhc2trees:mango_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:jungle_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "pamhc2trees:mangoitem"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.01,
+      "output": {
+        "item": "minecraft:jungle_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+        "chance": 0.001,
+        "output": {
+          "item": "pamhc2trees:mango_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/maple_sapling.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/maple_sapling.json
@@ -1,0 +1,69 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "pamhc2trees:maple_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "pamhc2trees:maple_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "pamhc2trees:maple_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:spruce_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "pamhc2trees:pammaple"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "pamhc2trees:maplesyrupitem"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.01,
+      "output": {
+        "item": "minecraft:spruce_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+        "chance": 0.001,
+        "output": {
+          "item": "pamhc2trees:maple_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/nutmeg_sapling.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/nutmeg_sapling.json
@@ -1,0 +1,61 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "pamhc2trees:nutmeg_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "pamhc2trees:nutmeg_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "pamhc2trees:nutmeg_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:oak_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "pamhc2trees:nutmegitem"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.01,
+      "output": {
+        "item": "minecraft:oak_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+        "chance": 0.001,
+        "output": {
+          "item": "pamhc2trees:nutmeg_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/olive_sapling.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/olive_sapling.json
@@ -1,0 +1,61 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "pamhc2trees:olive_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "pamhc2trees:olive_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "pamhc2trees:olive_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:jungle_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "pamhc2trees:oliveitem"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.01,
+      "output": {
+        "item": "minecraft:jungle_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+        "chance": 0.001,
+        "output": {
+          "item": "pamhc2trees:olive_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/orange_sapling.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/orange_sapling.json
@@ -1,0 +1,61 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "pamhc2trees:orange_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "pamhc2trees:orange_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "pamhc2trees:orange_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:oak_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "pamhc2trees:orangeitem"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.01,
+      "output": {
+        "item": "minecraft:oak_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+        "chance": 0.001,
+        "output": {
+          "item": "pamhc2trees:orange_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/papaya_sapling.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/papaya_sapling.json
@@ -1,0 +1,61 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "pamhc2trees:papaya_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "pamhc2trees:papaya_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "pamhc2trees:papaya_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:jungle_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "pamhc2trees:papayaitem"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.01,
+      "output": {
+        "item": "minecraft:jungle_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+        "chance": 0.001,
+        "output": {
+          "item": "pamhc2trees:papaya_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/paperbark_sapling.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/paperbark_sapling.json
@@ -1,0 +1,69 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "pamhc2trees:paperbark_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "pamhc2trees:paperbark_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "pamhc2trees:paperbark_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:jungle_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "pamhc2trees:pampaperbark"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:paper"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.01,
+      "output": {
+        "item": "minecraft:jungle_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+        "chance": 0.001,
+        "output": {
+          "item": "pamhc2trees:paperbark_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/passionfruit_sapling.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/passionfruit_sapling.json
@@ -1,0 +1,61 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "pamhc2trees:passionfruit_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "pamhc2trees:passionfruit_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "pamhc2trees:passionfruit_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:jungle_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "pamhc2trees:passionfruititem"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.01,
+      "output": {
+        "item": "minecraft:jungle_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+        "chance": 0.001,
+        "output": {
+          "item": "pamhc2trees:passionfruit_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/pawpaw_sapling.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/pawpaw_sapling.json
@@ -1,0 +1,61 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "pamhc2trees:pawpaw_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "pamhc2trees:pawpaw_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "pamhc2trees:pawpaw_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:oak_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "pamhc2trees:pawpawitem"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.01,
+      "output": {
+        "item": "minecraft:oak_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+        "chance": 0.001,
+        "output": {
+          "item": "pamhc2trees:pawpaw_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/peach_sapling.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/peach_sapling.json
@@ -1,0 +1,61 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "pamhc2trees:peach_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "pamhc2trees:peach_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "pamhc2trees:peach_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:oak_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "pamhc2trees:peachitem"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.01,
+      "output": {
+        "item": "minecraft:oak_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+        "chance": 0.001,
+        "output": {
+          "item": "pamhc2trees:peach_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/pear_sapling.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/pear_sapling.json
@@ -1,0 +1,61 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "pamhc2trees:pear_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "pamhc2trees:pear_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "pamhc2trees:pear_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:oak_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "pamhc2trees:pearitem"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.01,
+      "output": {
+        "item": "minecraft:oak_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+        "chance": 0.001,
+        "output": {
+          "item": "pamhc2trees:pear_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/pecan_sapling.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/pecan_sapling.json
@@ -1,0 +1,61 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "pamhc2trees:pecan_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "pamhc2trees:pecan_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "pamhc2trees:pecan_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:jungle_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "pamhc2trees:pecanitem"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.01,
+      "output": {
+        "item": "minecraft:jungle_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+        "chance": 0.001,
+        "output": {
+          "item": "pamhc2trees:pecan_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/peppercorn_sapling.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/peppercorn_sapling.json
@@ -1,0 +1,61 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "pamhc2trees:peppercorn_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "pamhc2trees:peppercorn_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "pamhc2trees:peppercorn_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:jungle_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "pamhc2trees:peppercornitem"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.01,
+      "output": {
+        "item": "minecraft:jungle_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+        "chance": 0.001,
+        "output": {
+          "item": "pamhc2trees:peppercorn_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/persimmon_sapling.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/persimmon_sapling.json
@@ -1,0 +1,61 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "pamhc2trees:persimmon_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "pamhc2trees:persimmon_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "pamhc2trees:persimmon_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:jungle_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "pamhc2trees:persimmonitem"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.01,
+      "output": {
+        "item": "minecraft:jungle_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+        "chance": 0.001,
+        "output": {
+          "item": "pamhc2trees:persimmon_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/pinenut_sapling.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/pinenut_sapling.json
@@ -1,0 +1,61 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "pamhc2trees:pinenut_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "pamhc2trees:pinenut_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "pamhc2trees:pinenut_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:spruce_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "pamhc2trees:pinenutitem"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.01,
+      "output": {
+        "item": "minecraft:spruce_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+        "chance": 0.001,
+        "output": {
+          "item": "pamhc2trees:pinenut_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/pistachio_sapling.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/pistachio_sapling.json
@@ -1,0 +1,61 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "pamhc2trees:pistachio_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "pamhc2trees:pistachio_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "pamhc2trees:pistachio_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:jungle_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "pamhc2trees:pistachioitem"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.01,
+      "output": {
+        "item": "minecraft:jungle_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+        "chance": 0.001,
+        "output": {
+          "item": "pamhc2trees:pistachio_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/plum_sapling.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/plum_sapling.json
@@ -1,0 +1,61 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "pamhc2trees:plum_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "pamhc2trees:plum_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "pamhc2trees:plum_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:oak_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "pamhc2trees:plumitem"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.01,
+      "output": {
+        "item": "minecraft:oak_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+        "chance": 0.001,
+        "output": {
+          "item": "pamhc2trees:plum_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/pomegranate_sapling.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/pomegranate_sapling.json
@@ -1,0 +1,61 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "pamhc2trees:pomegranate_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "pamhc2trees:pomegranate_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "pamhc2trees:pomegranate_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:jungle_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "pamhc2trees:pomegranateitem"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.01,
+      "output": {
+        "item": "minecraft:jungle_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+        "chance": 0.001,
+        "output": {
+          "item": "pamhc2trees:pomegranate_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/rambutan_sapling.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/rambutan_sapling.json
@@ -1,0 +1,61 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "pamhc2trees:rambutan_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "pamhc2trees:rambutan_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "pamhc2trees:rambutan_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:jungle_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "pamhc2trees:rambutanitem"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.01,
+      "output": {
+        "item": "minecraft:jungle_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+        "chance": 0.001,
+        "output": {
+          "item": "pamhc2trees:rambutan_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/soursop_sapling.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/soursop_sapling.json
@@ -1,0 +1,61 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "pamhc2trees:soursop_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "pamhc2trees:soursop_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "pamhc2trees:soursop_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:oak_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "pamhc2trees:soursopitem"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.01,
+      "output": {
+        "item": "minecraft:oak_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+        "chance": 0.001,
+        "output": {
+          "item": "pamhc2trees:soursop_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/spiderweb_sapling.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/spiderweb_sapling.json
@@ -1,0 +1,61 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "pamhc2trees:spiderweb_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "pamhc2trees:spiderweb_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "pamhc2trees:spiderweb_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:oak_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:string"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.01,
+      "output": {
+        "item": "minecraft:oak_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+        "chance": 0.001,
+        "output": {
+          "item": "pamhc2trees:spiderweb_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/starfruit_sapling.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/starfruit_sapling.json
@@ -1,0 +1,61 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "pamhc2trees:starfruit_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "pamhc2trees:starfruit_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "pamhc2trees:starfruit_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:jungle_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "pamhc2trees:starfruititem"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.01,
+      "output": {
+        "item": "minecraft:jungle_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+        "chance": 0.001,
+        "output": {
+          "item": "pamhc2trees:starfruit_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/tamarind_sapling.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/tamarind_sapling.json
@@ -1,0 +1,61 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "pamhc2trees:tamarind_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "pamhc2trees:tamarind_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "pamhc2trees:tamarind_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:jungle_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "pamhc2trees:tamarinditem"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.01,
+      "output": {
+        "item": "minecraft:jungle_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+        "chance": 0.001,
+        "output": {
+          "item": "pamhc2trees:tamarind_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/vanillabean_sapling.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/vanillabean_sapling.json
@@ -1,0 +1,61 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "pamhc2trees:vanillabean_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "pamhc2trees:vanillabean_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "pamhc2trees:vanillabean_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:jungle_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "pamhc2trees:vanillabeanitem"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.01,
+      "output": {
+        "item": "minecraft:jungle_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+        "chance": 0.001,
+        "output": {
+          "item": "pamhc2trees:vanillabean_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/walnut_sapling.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/pamhc2trees/walnut_sapling.json
@@ -1,0 +1,61 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "pamhc2trees:walnut_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "pamhc2trees:walnut_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "pamhc2trees:walnut_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:oak_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "pamhc2trees:walnutitem"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.01,
+      "output": {
+        "item": "minecraft:oak_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+        "chance": 0.001,
+        "output": {
+          "item": "pamhc2trees:walnut_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/premiumwood/apple.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/premiumwood/apple.json
@@ -1,0 +1,53 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "premium_wood:apple_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "premium_wood:apple_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "premium_wood:apple_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:oak_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+      },
+      {
+        "chance": 0.25,
+        "output": {
+          "item": "minecraft:stick"
+        },
+        "minRolls": 1,
+        "maxRolls": 2
+    },
+    {
+      "chance": 0.25,
+      "output": {
+        "item": "minecraft:apple"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "premium_wood:apple_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/premiumwood/magic.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/premiumwood/magic.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "premium_wood:magic_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "premium_wood:magic_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "premium_wood:magic_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "premium_wood:magic_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+      },
+      {
+        "chance": 0.25,
+        "output": {
+          "item": "minecraft:stick"
+        },
+        "minRolls": 1,
+        "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "premium_wood:magic_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/premiumwood/maple.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/premiumwood/maple.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "premium_wood:maple_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "premium_wood:maple_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "premium_wood:maple_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "premium_wood:maple_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+      },
+      {
+        "chance": 0.25,
+        "output": {
+          "item": "minecraft:stick"
+        },
+        "minRolls": 1,
+        "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "premium_wood:maple_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/premiumwood/purple_heart.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/premiumwood/purple_heart.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "premium_wood:purple_heart_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "premium_wood:purple_heart_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "premium_wood:purple_heart_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "premium_wood:purple_heart_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+      },
+      {
+        "chance": 0.25,
+        "output": {
+          "item": "minecraft:stick"
+        },
+        "minRolls": 1,
+        "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "premium_wood:purple_heart_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/premiumwood/silverbell.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/premiumwood/silverbell.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "premium_wood:silverbell_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "premium_wood:silverbell_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "premium_wood:silverbell_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "premium_wood:silverbell_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+      },
+      {
+        "chance": 0.25,
+        "output": {
+          "item": "minecraft:stick"
+        },
+        "minRolls": 1,
+        "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "premium_wood:silverbell_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/premiumwood/tiger.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/premiumwood/tiger.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "premium_wood:tiger_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "premium_wood:tiger_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "premium_wood:tiger_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "premium_wood:tiger_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+      },
+      {
+        "chance": 0.25,
+        "output": {
+          "item": "minecraft:stick"
+        },
+        "minRolls": 1,
+        "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "premium_wood:tiger_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/premiumwood/willow.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/premiumwood/willow.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "premium_wood:willow_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "premium_wood:willow_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "premium_wood:willow_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "premium_wood:willow_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+      },
+      {
+        "chance": 0.25,
+        "output": {
+          "item": "minecraft:stick"
+        },
+        "minRolls": 1,
+        "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "premium_wood:willow_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/quark/fiery_blossom.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/quark/fiery_blossom.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "quark:red_blossom_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "quark:red_blossom_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "quark:red_blossom_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "quark:blossom_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "quark:red_blossom_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/quark/frosty_blossom.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/quark/frosty_blossom.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "quark:blue_blossom_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "quark:blue_blossom_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "quark:blue_blossom_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "quark:blossom_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "quark:blue_blossom_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/quark/serene_blossom.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/quark/serene_blossom.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "quark:lavender_blossom_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "quark:lavender_blossom_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "quark:lavender_blossom_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "quark:blossom_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "quark:lavender_blossom_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/quark/sunny_blossom.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/quark/sunny_blossom.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "quark:yellow_blossom_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "quark:yellow_blossom_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "quark:yellow_blossom_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "quark:blossom_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "quark:yellow_blossom_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/quark/sweet_blossom.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/quark/sweet_blossom.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "quark:pink_blossom_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "quark:pink_blossom_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "quark:pink_blossom_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "quark:blossom_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "quark:pink_blossom_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/quark/warm_blossom.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/quark/warm_blossom.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "quark:orange_blossom_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "quark:orange_blossom_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "quark:orange_blossom_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "quark:blossom_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "quark:orange_blossom_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/silentgear/netherwood.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/silentgear/netherwood.json
@@ -1,0 +1,53 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "silentgear:netherwood_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "silentgear:netherwood_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "silentgear:netherwood_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "silentgear:netherwood_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+      },
+      {
+        "chance": 0.25,
+        "output": {
+          "item": "silentgear:netherwood_stick"
+        },
+        "minRolls": 1,
+        "maxRolls": 2
+    },
+    {
+      "chance": 0.25,
+      "output": {
+        "item": "silentgear:nether_banana"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+      },
+      {
+        "chance": 0.15,
+        "output": {
+          "item": "silentgear:netherwood_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/simplefarming/apple.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/simplefarming/apple.json
@@ -1,0 +1,53 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "simplefarming:apple_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "simplefarming:apple_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "simplefarming:apple_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "simplefarming:fruit_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.01,
+      "output": {
+        "item": "simplefarming:apple_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.20,
+        "output": {
+          "item": "minecraft:apple"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/simplefarming/apricot.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/simplefarming/apricot.json
@@ -1,0 +1,53 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "simplefarming:apricot_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "simplefarming:apricot_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "simplefarming:apricot_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "simplefarming:fruit_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.01,
+      "output": {
+        "item": "simplefarming:apricot_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.20,
+        "output": {
+          "item": "simplefarming:apricot"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/simplefarming/banana.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/simplefarming/banana.json
@@ -1,0 +1,53 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "simplefarming:banana_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "simplefarming:banana_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "simplefarming:banana_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "simplefarming:fruit_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.01,
+      "output": {
+        "item": "simplefarming:banana_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.20,
+        "output": {
+          "item": "simplefarming:banana"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/simplefarming/cherry.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/simplefarming/cherry.json
@@ -1,0 +1,53 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "simplefarming:cherry_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "simplefarming:cherry_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "simplefarming:cherry_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "simplefarming:fruit_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.01,
+      "output": {
+        "item": "simplefarming:cherry_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.20,
+        "output": {
+          "item": "simplefarming:cherries"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/simplefarming/mango.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/simplefarming/mango.json
@@ -1,0 +1,53 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "simplefarming:mango_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "simplefarming:mango_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "simplefarming:mango_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "simplefarming:fruit_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.01,
+      "output": {
+        "item": "simplefarming:mango_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.20,
+        "output": {
+          "item": "simplefarming:mango"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/simplefarming/olive.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/simplefarming/olive.json
@@ -1,0 +1,53 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "simplefarming:olive_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "simplefarming:olive_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "simplefarming:olive_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "simplefarming:fruit_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.01,
+      "output": {
+        "item": "simplefarming:olive_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.20,
+        "output": {
+          "item": "simplefarming:olives"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/simplefarming/orange.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/simplefarming/orange.json
@@ -1,0 +1,53 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "simplefarming:orange_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "simplefarming:orange_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "simplefarming:orange_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "simplefarming:fruit_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.01,
+      "output": {
+        "item": "simplefarming:orange_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.20,
+        "output": {
+          "item": "simplefarming:orange"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/simplefarming/pear.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/simplefarming/pear.json
@@ -1,0 +1,53 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "simplefarming:pear_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "simplefarming:pear_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "simplefarming:pear_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "simplefarming:fruit_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.01,
+      "output": {
+        "item": "simplefarming:pear_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.20,
+        "output": {
+          "item": "simplefarming:pear"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/simplefarming/plum.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/simplefarming/plum.json
@@ -1,0 +1,53 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "simplefarming:plum_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "simplefarming:plum_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "simplefarming:plum_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "simplefarming:fruit_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.01,
+      "output": {
+        "item": "simplefarming:plum_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.20,
+        "output": {
+          "item": "simplefarming:plum"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/simplytea/tea.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/simplytea/tea.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "simplytea:tea_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "simplytea:tea_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "simplytea:tea_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "simplytea:tea_leaf"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+      },
+      {
+        "chance": 0.25,
+        "output": {
+          "item": "simplytea:tea_stick"
+        },
+        "minRolls": 1,
+        "maxRolls": 2
+      },
+      {
+        "chance": 0.15,
+        "output": {
+          "item": "simplytea:tea_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/tconstruct/enderslime.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/tconstruct/enderslime.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "tconstruct:ender_slime_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "tconstruct:ender_slime_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "tconstruct:ender_slime_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "tconstruct:greenheart_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+      },
+      {
+        "chance": 0.25,
+        "output": {
+          "item": "tconstruct:ender_slime_ball"
+        },
+        "minRolls": 1,
+        "maxRolls": 2
+      },
+      {
+        "chance": 0.05,
+        "output": {
+          "item": "tconstruct:ender_slime_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/tconstruct/greenheart.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/tconstruct/greenheart.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "tconstruct:earth_slime_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "tconstruct:earth_slime_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "tconstruct:earth_slime_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "tconstruct:greenheart_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+      },
+      {
+        "chance": 0.25,
+        "output": {
+          "item": "minecraft:slime_ball"
+        },
+        "minRolls": 1,
+        "maxRolls": 2
+      },
+      {
+        "chance": 0.05,
+        "output": {
+          "item": "tconstruct:earth_slime_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/tconstruct/skyroot.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/tconstruct/skyroot.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "tconstruct:sky_slime_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "tconstruct:sky_slime_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "tconstruct:sky_slime_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "tconstruct:skyroot_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+      },
+      {
+        "chance": 0.25,
+        "output": {
+          "item": "tconstruct:sky_slime_ball"
+        },
+        "minRolls": 1,
+        "maxRolls": 2
+      },
+      {
+        "chance": 0.05,
+        "output": {
+          "item": "tconstruct:sky_slime_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/terraqueous/apple.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/terraqueous/apple.json
@@ -1,0 +1,53 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "terraqueous:apple_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "terraqueous:apple_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "terraqueous:apple_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "terraqueous:apple_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+      },
+      {
+        "chance": 0.25,
+        "output": {
+          "item": "minecraft:stick"
+        },
+        "minRolls": 1,
+        "maxRolls": 2
+    },
+    {
+        "chance": 0.50,
+        "output": {
+          "item": "minecraft:apple"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+      },
+      {
+        "chance": 0.01,
+        "output": {
+          "item": "terraqueous:apple_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/terraqueous/banana.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/terraqueous/banana.json
@@ -1,0 +1,53 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "terraqueous:banana_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "terraqueous:banana_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "terraqueous:banana_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "terraqueous:banana_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+      },
+      {
+        "chance": 0.25,
+        "output": {
+          "item": "minecraft:stick"
+        },
+        "minRolls": 1,
+        "maxRolls": 2
+    },
+    {
+        "chance": 0.50,
+        "output": {
+          "item": "terraqueous:banana"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+      },
+      {
+        "chance": 0.01,
+        "output": {
+          "item": "terraqueous:banana_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/terraqueous/cherry.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/terraqueous/cherry.json
@@ -1,0 +1,53 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "terraqueous:cherry_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "terraqueous:cherry_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "terraqueous:cherry_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "terraqueous:cherry_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+      },
+      {
+        "chance": 0.25,
+        "output": {
+          "item": "minecraft:stick"
+        },
+        "minRolls": 1,
+        "maxRolls": 2
+    },
+    {
+        "chance": 0.50,
+        "output": {
+          "item": "terraqueous:cherry"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+      },
+      {
+        "chance": 0.01,
+        "output": {
+          "item": "terraqueous:cherry_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/terraqueous/coconut.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/terraqueous/coconut.json
@@ -1,0 +1,53 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "terraqueous:coconut_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "terraqueous:coconut_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "terraqueous:coconut_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "terraqueous:coconut_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+      },
+      {
+        "chance": 0.25,
+        "output": {
+          "item": "minecraft:stick"
+        },
+        "minRolls": 1,
+        "maxRolls": 2
+    },
+    {
+        "chance": 0.50,
+        "output": {
+          "item": "terraqueous:coconut"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+      },
+      {
+        "chance": 0.01,
+        "output": {
+          "item": "terraqueous:coconut_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/terraqueous/lemon.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/terraqueous/lemon.json
@@ -1,0 +1,53 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "terraqueous:lemon_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "terraqueous:lemon_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "terraqueous:lemon_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "terraqueous:lemon_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+      },
+      {
+        "chance": 0.25,
+        "output": {
+          "item": "minecraft:stick"
+        },
+        "minRolls": 1,
+        "maxRolls": 2
+    },
+    {
+        "chance": 0.50,
+        "output": {
+          "item": "terraqueous:lemon"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+      },
+      {
+        "chance": 0.01,
+        "output": {
+          "item": "terraqueous:lemon_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/terraqueous/mango.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/terraqueous/mango.json
@@ -1,0 +1,53 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "terraqueous:mango_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "terraqueous:mango_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "terraqueous:mango_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "terraqueous:mango_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+      },
+      {
+        "chance": 0.25,
+        "output": {
+          "item": "minecraft:stick"
+        },
+        "minRolls": 1,
+        "maxRolls": 2
+    },
+    {
+        "chance": 0.50,
+        "output": {
+          "item": "terraqueous:mango"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+      },
+      {
+        "chance": 0.01,
+        "output": {
+          "item": "terraqueous:mango_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/terraqueous/mulberry.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/terraqueous/mulberry.json
@@ -1,0 +1,53 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "terraqueous:mulberry_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "terraqueous:mulberry_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "terraqueous:mulberry_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "terraqueous:mulberry_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+      },
+      {
+        "chance": 0.25,
+        "output": {
+          "item": "minecraft:stick"
+        },
+        "minRolls": 1,
+        "maxRolls": 2
+    },
+    {
+        "chance": 0.50,
+        "output": {
+          "item": "terraqueous:mulberry"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+      },
+      {
+        "chance": 0.01,
+        "output": {
+          "item": "terraqueous:mulberry_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/terraqueous/orange.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/terraqueous/orange.json
@@ -1,0 +1,53 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "terraqueous:orange_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "terraqueous:orange_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "terraqueous:orange_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "terraqueous:orange_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+      },
+      {
+        "chance": 0.25,
+        "output": {
+          "item": "minecraft:stick"
+        },
+        "minRolls": 1,
+        "maxRolls": 2
+    },
+    {
+        "chance": 0.50,
+        "output": {
+          "item": "terraqueous:orange"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+      },
+      {
+        "chance": 0.01,
+        "output": {
+          "item": "terraqueous:orange_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/terraqueous/peach.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/terraqueous/peach.json
@@ -1,0 +1,53 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "terraqueous:peach_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "terraqueous:peach_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "terraqueous:peach_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "terraqueous:peach_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+      },
+      {
+        "chance": 0.25,
+        "output": {
+          "item": "minecraft:stick"
+        },
+        "minRolls": 1,
+        "maxRolls": 2
+    },
+    {
+        "chance": 0.50,
+        "output": {
+          "item": "terraqueous:peach"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+      },
+      {
+        "chance": 0.01,
+        "output": {
+          "item": "terraqueous:peach_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/terraqueous/pear.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/terraqueous/pear.json
@@ -1,0 +1,53 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "terraqueous:pear_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "terraqueous:pear_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "terraqueous:pear_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "terraqueous:pear_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+      },
+      {
+        "chance": 0.25,
+        "output": {
+          "item": "minecraft:stick"
+        },
+        "minRolls": 1,
+        "maxRolls": 2
+    },
+    {
+        "chance": 0.50,
+        "output": {
+          "item": "terraqueous:pear"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+      },
+      {
+        "chance": 0.01,
+        "output": {
+          "item": "terraqueous:pear_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/terraqueous/plum.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/terraqueous/plum.json
@@ -1,0 +1,53 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "terraqueous:plum_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "terraqueous:plum_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "terraqueous:plum_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "terraqueous:plum_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+      },
+      {
+        "chance": 0.25,
+        "output": {
+          "item": "minecraft:stick"
+        },
+        "minRolls": 1,
+        "maxRolls": 2
+    },
+    {
+        "chance": 0.50,
+        "output": {
+          "item": "terraqueous:plum"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+      },
+      {
+        "chance": 0.01,
+        "output": {
+          "item": "terraqueous:plum_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/twilightforest/canopy.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/twilightforest/canopy.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "twilightforest:canopy_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "twilightforest:canopy_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "twilightforest:canopy_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "twilightforest:canopy_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "twilightforest:canopy_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/twilightforest/darkwood.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/twilightforest/darkwood.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "twilightforest:darkwood_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "twilightforest:darkwood_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "twilightforest:darkwood_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "twilightforest:dark_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "twilightforest:darkwood_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/twilightforest/mangrove.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/twilightforest/mangrove.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "twilightforest:mangrove_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "twilightforest:mangrove_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "twilightforest:mangrove_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "twilightforest:mangrove_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "twilightforest:mangrove_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/twilightforest/miners_tree.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/twilightforest/miners_tree.json
@@ -1,0 +1,53 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "twilightforest:mining_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "twilightforest:mining_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "twilightforest:mining_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "twilightforest:mining_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+        "chance": 0.05,
+        "output": {
+          "item": "twilightforest:mining_log_core"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "twilightforest:mining_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/twilightforest/rainbow_oak.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/twilightforest/rainbow_oak.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "twilightforest:rainbow_oak_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "twilightforest:rainbow_oak_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "twilightforest:rainbow_oak_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:oak_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "twilightforest:rainbow_oak_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/twilightforest/sickly_twilight_oak.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/twilightforest/sickly_twilight_oak.json
@@ -1,0 +1,53 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "twilightforest:twilight_oak_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "twilightforest:twilight_oak_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "twilightforest:twilight_oak_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "twilightforest:twilight_oak_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.0005,
+      "output": {
+        "item": "twilightforest:hollow_oak_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "twilightforest:twilight_oak_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/twilightforest/sortingwood.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/twilightforest/sortingwood.json
@@ -1,0 +1,53 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "twilightforest:sorting_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "twilightforest:sorting_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "twilightforest:sorting_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "twilightforest:sorting_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+        "chance": 0.05,
+        "output": {
+          "item": "twilightforest:sorting_log_core"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "twilightforest:sorting_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/twilightforest/time_tree.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/twilightforest/time_tree.json
@@ -1,0 +1,53 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "twilightforest:time_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "twilightforest:time_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "twilightforest:time_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "twilightforest:time_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+        "chance": 0.05,
+        "output": {
+          "item": "twilightforest:time_log_core"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.001,
+        "output": {
+          "item": "twilightforest:time_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/twilightforest/transformation.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/twilightforest/transformation.json
@@ -1,0 +1,53 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "twilightforest:transformation_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "twilightforest:transformation_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "twilightforest:transformation_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "twilightforest:transformation_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+        "chance": 0.05,
+        "output": {
+          "item": "twilightforest:transformation_log_core"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "twilightforest:transformation_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/undergarden/grongle.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/undergarden/grongle.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "undergarden:grongle_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "undergarden:grongle_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "undergarden:grongle_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "undergarden:grongle_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.01,
+      "output": {
+        "item": "undergarden:gronglet"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "undergarden:grongle_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/undergarden/smogstem.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/undergarden/smogstem.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "undergarden:smogstem_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "undergarden:smogstem_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "undergarden:smogstem_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "undergarden:smogstem_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "undergarden:smogstem_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/undergarden/wigglewood.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/undergarden/wigglewood.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "undergarden:wigglewood_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "undergarden:wigglewood_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "undergarden:wigglewood_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "undergarden:wigglewood_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.25,
+      "output": {
+        "item": "undergarden:twistytwig"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "undergarden:wigglewood_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/uniquecrops/flywood.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/uniquecrops/flywood.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "uniquecrops:flywood_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "uniquecrops:flywood_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "uniquecrops:flywood_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "uniquecrops:flywood_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+      },
+      {
+        "chance": 0.25,
+        "output": {
+          "item": "minecraft:stick"
+        },
+        "minRolls": 1,
+        "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "uniquecrops:flywood_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/upgrade_aquatic/river.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/upgrade_aquatic/river.json
@@ -1,0 +1,53 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "upgrade_aquatic:river_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "upgrade_aquatic:river_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "upgrade_aquatic:river_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "upgrade_aquatic:river_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.10,
+      "output": {
+        "item": "upgrade_aquatic:mulberry"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "upgrade_aquatic:river_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/vampirism/bloody_spruce.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/vampirism/bloody_spruce.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "vampirism:bloody_spruce_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "vampirism:bloody_spruce_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "vampirism:bloody_spruce_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "vampirism:bloody_spruce_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+      },
+      {
+        "chance": 0.25,
+        "output": {
+          "item": "minecraft:stick"
+        },
+        "minRolls": 1,
+        "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "vampirism:bloody_spruce_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/vampirism/vampire_spruce.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/vampirism/vampire_spruce.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "vampirism:vampire_spruce_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "vampirism:vampire_spruce_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "vampirism:vampire_spruce_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:spruce_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+      },
+      {
+        "chance": 0.25,
+        "output": {
+          "item": "minecraft:stick"
+        },
+        "minRolls": 1,
+        "maxRolls": 2
+    },
+    {
+        "chance": 0.01,
+        "output": {
+          "item": "vampirism:vampire_spruce_sapling"
+        }
+      }
+    ]
+  }

--- a/README.md
+++ b/README.md
@@ -1,0 +1,2 @@
+# BotanyTrees
+Allows you to grow trees in small pots.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
-# BotanyTrees
-Allows you to grow trees in small pots.
+# Botany Trees [![](http://cf.way2muchnoise.eu/353928.svg)](https://www.curseforge.com/minecraft/mc-mods/botany-trees) [![](http://cf.way2muchnoise.eu/versions/353928.svg)](https://www.curseforge.com/minecraft/mc-mods/botany-trees)
+
+This mod adds support to other mods' trees to work in Botany Pots!
+
+[![Nodecraft](https://i.imgur.com/sz9PUmK.png)](https://nodecraft.com/r/darkhax)    
+This project is sponsored by Nodecraft. Use code [Darkhax](https://nodecraft.com/r/darkhax) for 30% off your first month
+of service!
+
+## Source Code
+
+The latest source code can be found here on [GitHub](https://github.com/Darkhax-Minecraft/BotanyTrees)


### PR DESCRIPTION
This is a massive pull request to update Botany Trees to add much needed support.

This pull request will add support for the following mods and their trees:

Ecologics
Simply Tea
Silent Gear
Vampirism
Terraqueous
Forbidden & Arcanus
Premium Wood
Industrial Reborn
Integrated Dynamics
Malum
All You Can Eat
MyrTrees
Fruit Trees
Assembly Line Machines
Nature's Aura
Unique Crops
Architect's Palette
EvilCraft
Mo Shiz' Mod
Allthemodium
Quark
BYG
The Undergarden
Ars Nouveau
Biome Makeover
Simple Farming
Enhanced Farming
Blue Skies
Twilight Forest
Autumnity
Atmospheric
Environmental
Upgrade Aquatic
Pam's HarvestCraft2: Trees
Biomes o' Plenty
Croptopia
Tinkers Construct.

ALL of this has been tested and it works well. Important thing to note: Not all of these are released, but have been supported so when they do, or a beta is released, they will have their supports. 