### PR TITLE
Fix A Mod's Tree Compat (1.18.2)

### DIFF
--- a/Common/src/main/resources/data/botanytrees/recipes/moshizmod/cherry.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/moshizmod/cherry.json
@@ -3,26 +3,26 @@
       {
         "type": "bookshelf:item_exists",
         "values": [
-          "ms:nature/cherrysapling"
+          "ms:nature/cherry_sapling"
         ]
       }
     ],
     "type": "botanypots:crop",
     "seed": {
-      "item": "ms:nature/cherrysapling"
+      "item": "ms:nature/cherry_sapling"
     },
     "categories": [
       "dirt"
     ],
     "growthTicks": 2400,
     "display": {
-      "block": "ms:nature/cherrysapling"
+      "block": "ms:nature/cherry_sapling"
     },
     "drops": [
       {
         "chance": 1.00,
         "output": {
-          "item": "ms:nature/cherrylog"
+          "item": "ms:nature/cherry_log"
         },
         "minRolls": 2,
         "maxRolls": 4
@@ -38,7 +38,7 @@
     {
         "chance": 0.01,
         "output": {
-          "item": "ms:nature/cherrysapling"
+          "item": "ms:nature/cherry_sapling"
         }
       }
     ]

--- a/Common/src/main/resources/data/botanytrees/recipes/moshizmod/glowood.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/moshizmod/glowood.json
@@ -9,20 +9,20 @@
     ],
     "type": "botanypots:crop",
     "seed": {
-      "item": "ms:nature/glowsapling"
+      "item": "ms:nature/glowood_sapling"
     },
     "categories": [
       "netherrack"
     ],
     "growthTicks": 2400,
     "display": {
-      "block": "ms:nature/glowsapling"
+      "block": "ms:nature/glowood_sapling"
     },
     "drops": [
       {
         "chance": 1.00,
         "output": {
-          "item": "ms:nature/glowoodlog"
+          "item": "ms:nature/glowood_log"
         },
         "minRolls": 2,
         "maxRolls": 4
@@ -38,7 +38,7 @@
     {
         "chance": 0.01,
         "output": {
-          "item": "ms:nature/glowsapling"
+          "item": "ms:nature/glowood_sapling"
         }
       }
     ]

--- a/Common/src/main/resources/data/botanytrees/recipes/moshizmod/glowood.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/moshizmod/glowood.json
@@ -3,7 +3,7 @@
       {
         "type": "bookshelf:item_exists",
         "values": [
-          "ms:nature/glowsapling"
+          "ms:nature/glowood_sapling"
         ]
       }
     ],

--- a/Common/src/main/resources/data/botanytrees/recipes/moshizmod/maple.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/moshizmod/maple.json
@@ -3,26 +3,26 @@
       {
         "type": "bookshelf:item_exists",
         "values": [
-          "ms:nature/maplesapling"
+          "ms:nature/maple_sapling"
         ]
       }
     ],
     "type": "botanypots:crop",
     "seed": {
-      "item": "ms:nature/maplesapling"
+      "item": "ms:nature/maple_sapling"
     },
     "categories": [
       "dirt"
     ],
     "growthTicks": 2400,
     "display": {
-      "block": "ms:nature/maplesapling"
+      "block": "ms:nature/maple_sapling"
     },
     "drops": [
       {
         "chance": 1.00,
         "output": {
-          "item": "ms:nature/maplelog"
+          "item": "ms:nature/maple_log"
         },
         "minRolls": 2,
         "maxRolls": 4
@@ -38,7 +38,7 @@
     {
         "chance": 0.01,
         "output": {
-          "item": "ms:nature/maplesapling"
+          "item": "ms:nature/maple_sapling"
         }
       }
     ]

--- a/Common/src/main/resources/data/botanytrees/recipes/moshizmod/tigerwood.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/moshizmod/tigerwood.json
@@ -3,26 +3,26 @@
       {
         "type": "bookshelf:item_exists",
         "values": [
-          "ms:nature/tigerwoodsapling"
+          "ms:nature/tigerwood_sapling"
         ]
       }
     ],
     "type": "botanypots:crop",
     "seed": {
-      "item": "ms:nature/tigerwoodsapling"
+      "item": "ms:nature/tigerwood_sapling"
     },
     "categories": [
       "dirt"
     ],
     "growthTicks": 2400,
     "display": {
-      "block": "ms:nature/tigerwoodsapling"
+      "block": "ms:nature/tigerwood_sapling"
     },
     "drops": [
       {
         "chance": 1.00,
         "output": {
-          "item": "ms:nature/tigerwoodlog"
+          "item": "ms:nature/tigerwood_log"
         },
         "minRolls": 2,
         "maxRolls": 4
@@ -38,7 +38,7 @@
     {
         "chance": 0.01,
         "output": {
-          "item": "ms:nature/tigerwoodsapling"
+          "item": "ms:nature/tigerwood_sapling"
         }
       }
     ]

--- a/Common/src/main/resources/data/botanytrees/recipes/moshizmod/willow.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/moshizmod/willow.json
@@ -3,26 +3,26 @@
       {
         "type": "bookshelf:item_exists",
         "values": [
-          "ms:nature/willowsapling"
+          "ms:nature/willow_sapling"
         ]
       }
     ],
     "type": "botanypots:crop",
     "seed": {
-      "item": "ms:nature/willowsapling"
+      "item": "ms:nature/willow_sapling"
     },
     "categories": [
       "dirt"
     ],
     "growthTicks": 2400,
     "display": {
-      "block": "ms:nature/willowsapling"
+      "block": "ms:nature/willow_sapling"
     },
     "drops": [
       {
         "chance": 1.00,
         "output": {
-          "item": "ms:nature/willowlog"
+          "item": "ms:nature/willow_log"
         },
         "minRolls": 2,
         "maxRolls": 4
@@ -38,7 +38,7 @@
     {
         "chance": 0.01,
         "output": {
-          "item": "ms:nature/willowsapling"
+          "item": "ms:nature/willow_sapling"
         }
       }
     ]


### PR DESCRIPTION
This simply fixes tree compat with Mo Shiz, which updated recently and changed all the item name spaces. 