### PR TITLE
(1.19.2+) Add support for various different mods

### DIFF
--- a/Common/src/main/resources/data/botanytrees/recipes/aether/golden_oak.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/aether/golden_oak.json
@@ -1,0 +1,46 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "aether:golden_oak_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "aether:golden_oak_sapling"
+    },
+    "categories": [
+      "dirt",
+      "aether_dirt"
+    ],
+    "growthTicks": 2750,
+    "display": {
+      "block": "aether:golden_oak_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "aether:golden_oak_log"
+        },
+        "minRolls": 1,
+        "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "aether:skyroot_stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.10,
+        "output": {
+          "item": "aether:golden_oak_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/aether/skyroot.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/aether/skyroot.json
@@ -1,0 +1,46 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "aether:skyroot_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "aether:skyroot_sapling"
+    },
+    "categories": [
+      "dirt",
+      "aether_dirt"
+    ],
+    "growthTicks": 2750,
+    "display": {
+      "block": "aether:skyroot_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "aether:skyroot_log"
+        },
+        "minRolls": 1,
+        "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "aether:skyroot_stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.10,
+        "output": {
+          "item": "aether:skyroot_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/aether_redux/blighted_skyroot.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/aether_redux/blighted_skyroot.json
@@ -1,0 +1,46 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "aether_redux:blighted_skyroot_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "aether_redux:blighted_skyroot_sapling"
+    },
+    "categories": [
+      "dirt",
+      "aether_dirt"
+    ],
+    "growthTicks": 2750,
+    "display": {
+      "block": "aether_redux:blighted_skyroot_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "aether:skyroot_log"
+        },
+        "minRolls": 1,
+        "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "aether:skyroot_stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.10,
+        "output": {
+          "item": "aether_redux:blighted_skyroot_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/aether_redux/blightwillow.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/aether_redux/blightwillow.json
@@ -1,0 +1,62 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "aether_redux:blightwillow_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "aether_redux:blightwillow_sapling"
+    },
+    "categories": [
+      "dirt",
+      "aether_dirt"
+    ],
+    "growthTicks": 2750,
+    "display": {
+      "block": "aether_redux:blightwillow_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "aether_redux:blightwillow_log"
+        },
+        "minRolls": 1,
+        "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "aether:skyroot_stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "aether_redux:blightwillow_roots"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.02,
+      "output": {
+        "item": "aether_redux:sporing_blightwillow_log"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+        "chance": 0.10,
+        "output": {
+          "item": "aether_redux:blightwillow_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/aether_redux/flowering_fieldsprout.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/aether_redux/flowering_fieldsprout.json
@@ -1,0 +1,54 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "aether_redux:flowering_fieldsprout_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "aether_redux:flowering_fieldsprout_sapling"
+    },
+    "categories": [
+      "dirt",
+      "aether_dirt"
+    ],
+    "growthTicks": 2750,
+    "display": {
+      "block": "aether_redux:flowering_fieldsprout_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "aether_redux:fieldsprout_log"
+        },
+        "minRolls": 1,
+        "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "aether:skyroot_stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "aether_redux:fieldsprout_petals"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+        "chance": 0.10,
+        "output": {
+          "item": "aether_redux:flowering_fieldsprout_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/aether_redux/gilded_oak.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/aether_redux/gilded_oak.json
@@ -1,0 +1,78 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "aether_redux:gilded_oak_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "aether_redux:gilded_oak_sapling"
+    },
+    "categories": [
+      "dirt",
+      "aether_dirt"
+    ],
+    "growthTicks": 2750,
+    "display": {
+      "block": "aether_redux:gilded_oak_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "aether:skyroot_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 3
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "aether:skyroot_stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "aether_redux:gilded_vines"
+      },
+      "minRolls": 4,
+      "maxRolls": 6
+    },
+    {
+      "chance": 0.10,
+      "output": {
+        "item": "aether_redux:gilded_leaf_pile"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "aether:skyroot_stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+      "chance": 0.02,
+      "output": {
+        "item": "aether:golden_skyroot_log"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+        "chance": 0.10,
+        "output": {
+          "item": "aether_redux:gilded_oak_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/aether_redux/glacia.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/aether_redux/glacia.json
@@ -1,0 +1,46 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "aether_redux:glacia_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "aether_redux:glacia_sapling"
+    },
+    "categories": [
+      "dirt",
+      "aether_dirt"
+    ],
+    "growthTicks": 2750,
+    "display": {
+      "block": "aether_redux:glacia_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "aether_redux:glacia_log"
+        },
+        "minRolls": 1,
+        "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "aether:skyroot_stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.10,
+        "output": {
+          "item": "aether_redux:glacia_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/caupona/fig.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/caupona/fig.json
@@ -1,0 +1,53 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "caupona:fig_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "caupona:fig_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "caupona:fig_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "caupona:fig_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "caupona:fig_fruits"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.15,
+        "output": {
+          "item": "caupona:fig_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/caupona/walnut.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/caupona/walnut.json
@@ -1,0 +1,53 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "caupona:walnut_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "caupona:walnut_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "caupona:walnut_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "caupona:walnut_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "caupona:walnut_fruits"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.15,
+        "output": {
+          "item": "caupona:walnut_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/caupona/wolfberry.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/caupona/wolfberry.json
@@ -1,0 +1,53 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "caupona:wolfberry_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "caupona:wolfberry_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "caupona:wolfberry_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "caupona:wolfberry_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "caupona:wolfberry_fruits"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.15,
+        "output": {
+          "item": "caupona:wolfberry_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/culturaldelights/avocado.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/culturaldelights/avocado.json
@@ -1,0 +1,53 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "culturaldelights:avocado_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "culturaldelights:avocado_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "culturaldelights:avocado_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "culturaldelights:avocado_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "culturaldelights:avocado"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.15,
+        "output": {
+          "item": "culturaldelights:avocado_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/deep_aether/blue_roseroot.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/deep_aether/blue_roseroot.json
@@ -1,0 +1,46 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "deep_aether:blue_roseroot_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "deep_aether:blue_roseroot_sapling"
+    },
+    "categories": [
+      "dirt",
+      "aether_dirt"
+    ],
+    "growthTicks": 2750,
+    "display": {
+      "block": "deep_aether:blue_roseroot_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "deep_aether:roseroot_log"
+        },
+        "minRolls": 1,
+        "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "aether:skyroot_stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.10,
+        "output": {
+          "item": "deep_aether:blue_roseroot_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/deep_aether/conberry.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/deep_aether/conberry.json
@@ -1,0 +1,46 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "deep_aether:conberry_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "deep_aether:conberry_sapling"
+    },
+    "categories": [
+      "dirt",
+      "aether_dirt"
+    ],
+    "growthTicks": 2750,
+    "display": {
+      "block": "deep_aether:conberry_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "deep_aether:conberry_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 3
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "aether:skyroot_stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.10,
+        "output": {
+          "item": "deep_aether:conberry_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/deep_aether/cruderoot.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/deep_aether/cruderoot.json
@@ -1,0 +1,46 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "deep_aether:cruderoot_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "deep_aether:cruderoot_sapling"
+    },
+    "categories": [
+      "dirt",
+      "aether_dirt"
+    ],
+    "growthTicks": 2750,
+    "display": {
+      "block": "deep_aether:cruderoot_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "deep_aether:cruderoot_log"
+        },
+        "minRolls": 1,
+        "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "aether:skyroot_stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.10,
+        "output": {
+          "item": "deep_aether:cruderoot_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/deep_aether/roseroot.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/deep_aether/roseroot.json
@@ -1,0 +1,46 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "deep_aether:roseroot_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "deep_aether:roseroot_sapling"
+    },
+    "categories": [
+      "dirt",
+      "aether_dirt"
+    ],
+    "growthTicks": 2750,
+    "display": {
+      "block": "deep_aether:roseroot_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "deep_aether:roseroot_log"
+        },
+        "minRolls": 1,
+        "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "aether:skyroot_stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.10,
+        "output": {
+          "item": "deep_aether:roseroot_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/deep_aether/sunroot.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/deep_aether/sunroot.json
@@ -1,0 +1,54 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "deep_aether:sunroot_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "deep_aether:sunroot_sapling"
+    },
+    "categories": [
+      "dirt",
+      "aether_dirt"
+    ],
+    "growthTicks": 2750,
+    "display": {
+      "block": "deep_aether:sunroot_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "deep_aether:sunroot_log"
+        },
+        "minRolls": 1,
+        "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "aether:skyroot_stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "deep_aether:sunroot_hanger"
+      },
+      "minRolls": 2,
+      "maxRolls": 3
+    },
+    {
+        "chance": 0.10,
+        "output": {
+          "item": "deep_aether:sunroot_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/deep_aether/yagroot.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/deep_aether/yagroot.json
@@ -1,0 +1,70 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "deep_aether:yagroot_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "deep_aether:yagroot_sapling"
+    },
+    "categories": [
+      "dirt",
+      "aether_dirt"
+    ],
+    "growthTicks": 2750,
+    "display": {
+      "block": "deep_aether:yagroot_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "deep_aether:yagroot_log"
+        },
+        "minRolls": 1,
+        "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "aether:skyroot_stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.10,
+      "output": {
+        "item": "deep_aether:yagroot_roots"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.10,
+      "output": {
+        "item": "deep_aether:yagroot_vine"
+      },
+      "minRolls": 2,
+      "maxRolls": 3
+    },
+    {
+      "chance": 0.10,
+      "output": {
+        "item": "deep_aether:aether_moss_carpet"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.10,
+        "output": {
+          "item": "deep_aether:yagroot_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/deeperdarker/echo.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/deeperdarker/echo.json
@@ -3,42 +3,50 @@
       {
         "type": "bookshelf:item_exists",
         "values": [
-          "forbidden_arcanus:growing_edelwood"
+          "deeperdarker:echo_sapling"
         ]
       }
     ],
     "type": "botanypots:crop",
     "seed": {
-      "item": "forbidden_arcanus:growing_edelwood"
+      "item": "deeperdarker:echo_sapling"
     },
     "categories": [
       "dirt"
     ],
     "growthTicks": 2400,
     "display": {
-      "block": "forbidden_arcanus:growing_edelwood"
+      "block": "deeperdarker:echo_sapling"
     },
     "drops": [
       {
-        "chance": 0.50,
+        "chance": 1.00,
         "output": {
-          "item": "forbidden_arcanus:edelwood_log"
+          "item": "deeperdarker:echo_log"
         },
-        "minRolls": 1,
-        "maxRolls": 2
+        "minRolls": 2,
+        "maxRolls": 4
       },
       {
         "chance": 0.25,
         "output": {
-          "item": "forbidden_arcanus:edelwood_branch"
+          "item": "minecraft:stick"
         },
         "minRolls": 1,
         "maxRolls": 2
     },
     {
+        "chance": 0.10,
+        "output": {
+          "item": "deeperdarker:sculk_gleam"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
         "chance": 0.15,
         "output": {
-          "item": "forbidden_arcanus:growing_edelwood"
+          "item": "deeperdarker:echo_sapling"
         }
       }
     ]

--- a/Common/src/main/resources/data/botanytrees/recipes/eidolon/illwood.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/eidolon/illwood.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "eidolon:illwood_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "eidolon:illwood_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2750,
+    "display": {
+      "block": "eidolon:illwood_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "eidolon:illwood_log"
+        },
+        "minRolls": 1,
+        "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.10,
+        "output": {
+          "item": "eidolon:illwood_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/ends_phantasm/pream.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/ends_phantasm/pream.json
@@ -1,0 +1,37 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "phantasm:pream_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "phantasm:pream_sapling"
+    },
+    "categories": [
+      "end_stone"
+    ],
+    "growthTicks": 2750,
+    "display": {
+      "block": "phantasm:pream_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "phantasm:pream_log"
+        },
+        "minRolls": 1,
+        "maxRolls": 2
+    },
+    {
+        "chance": 0.10,
+        "output": {
+          "item": "phantasm:pream_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/forbiddenarcanus/aurum.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/forbiddenarcanus/aurum.json
@@ -3,42 +3,50 @@
       {
         "type": "bookshelf:item_exists",
         "values": [
-          "forbidden_arcanus:growing_edelwood"
+          "forbidden_arcanus:aurum_sapling"
         ]
       }
     ],
     "type": "botanypots:crop",
     "seed": {
-      "item": "forbidden_arcanus:growing_edelwood"
+      "item": "forbidden_arcanus:aurum_sapling"
     },
     "categories": [
       "dirt"
     ],
     "growthTicks": 2400,
     "display": {
-      "block": "forbidden_arcanus:growing_edelwood"
+      "block": "forbidden_arcanus:aurum_sapling"
     },
     "drops": [
       {
-        "chance": 0.50,
+        "chance": 1.00,
         "output": {
-          "item": "forbidden_arcanus:edelwood_log"
+          "item": "forbidden_arcanus:aurum_log"
         },
-        "minRolls": 1,
-        "maxRolls": 2
+        "minRolls": 2,
+        "maxRolls": 4
       },
       {
         "chance": 0.25,
         "output": {
-          "item": "forbidden_arcanus:edelwood_branch"
+          "item": "minecraft:stick"
         },
         "minRolls": 1,
         "maxRolls": 2
     },
     {
+      "chance": 0.15,
+      "output": {
+        "item": "minecraft:gold_nugget"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
         "chance": 0.15,
         "output": {
-          "item": "forbidden_arcanus:growing_edelwood"
+          "item": "forbidden_arcanus:aurum_sapling"
         }
       }
     ]

--- a/Common/src/main/resources/data/botanytrees/recipes/forbiddenarcanus/cherry.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/forbiddenarcanus/cherry.json
@@ -1,0 +1,69 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "forbidden_arcanus:cherry_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "forbidden_arcanus:cherry_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "forbidden_arcanus:cherry_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "forbidden_arcanus:cherry_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+      },
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "forbidden_arcanus:thin_cherry_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+      },
+      {
+        "chance": 0.25,
+        "output": {
+          "item": "minecraft:stick"
+        },
+        "minRolls": 1,
+        "maxRolls": 2
+    },
+    {
+        "chance": 0.10,
+        "output": {
+          "item": "forbidden_arcanus:cherry_flower_vines"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+      },
+      {
+      "chance": 0.25,
+      "output": {
+        "item": "forbidden_arcanus:cherry_leaf_carpet"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.15,
+        "output": {
+          "item": "forbidden_arcanus:cherry_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/goodending/cypress.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/goodending/cypress.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "goodending:cypress_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "goodending:cypress_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2750,
+    "display": {
+      "block": "goodending:cypress_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "goodending:cypress_log"
+        },
+        "minRolls": 1,
+        "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.10,
+        "output": {
+          "item": "goodending:cypress_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/ic2/rubberwood.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/ic2/rubberwood.json
@@ -3,34 +3,26 @@
       {
         "type": "bookshelf:item_exists",
         "values": [
-          "forbidden_arcanus:growing_edelwood"
+          "ic2:rubber_sapling"
         ]
       }
     ],
     "type": "botanypots:crop",
     "seed": {
-      "item": "forbidden_arcanus:growing_edelwood"
+      "item": "ic2:rubber_sapling"
     },
     "categories": [
       "dirt"
     ],
     "growthTicks": 2400,
     "display": {
-      "block": "forbidden_arcanus:growing_edelwood"
+      "block": "ic2:rubber_sapling"
     },
     "drops": [
       {
         "chance": 0.50,
         "output": {
-          "item": "forbidden_arcanus:edelwood_log"
-        },
-        "minRolls": 1,
-        "maxRolls": 2
-      },
-      {
-        "chance": 0.25,
-        "output": {
-          "item": "forbidden_arcanus:edelwood_branch"
+          "item": "ic2:rubber_wood"
         },
         "minRolls": 1,
         "maxRolls": 2
@@ -38,7 +30,7 @@
     {
         "chance": 0.15,
         "output": {
-          "item": "forbidden_arcanus:growing_edelwood"
+          "item": "ic2:rubber_sapling"
         }
       }
     ]

--- a/Common/src/main/resources/data/botanytrees/recipes/nethers_exoticism/jabuticaba.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/nethers_exoticism/jabuticaba.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "nethers_exoticism:jaboticaba_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "nethers_exoticism:jaboticaba_sapling"
+    },
+    "categories": [
+      "blackstone"
+    ],
+    "growthTicks": 2750,
+    "display": {
+      "block": "nethers_exoticism:jaboticaba_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "nethers_exoticism:jaboticaba_branch"
+        },
+        "minRolls": 3,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "nethers_exoticism:jaboticaba"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.10,
+        "output": {
+          "item": "nethers_exoticism:jaboticaba_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/nethers_exoticism/kiwano.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/nethers_exoticism/kiwano.json
@@ -1,0 +1,46 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "nethers_exoticism:kiwano_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "nethers_exoticism:kiwano_sapling"
+    },
+    "categories": [
+      "nylium",
+      "netherrack"
+    ],
+    "growthTicks": 2750,
+    "display": {
+      "block": "nethers_exoticism:kiwano_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:warped_stem"
+        },
+        "minRolls": 1,
+        "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "nethers_exoticism:kiwano"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.10,
+        "output": {
+          "item": "nethers_exoticism:kiwano_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/nethers_exoticism/rambutan.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/nethers_exoticism/rambutan.json
@@ -1,0 +1,46 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "nethers_exoticism:ramboutan_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "nethers_exoticism:ramboutan_sapling"
+    },
+    "categories": [
+      "nylium",
+      "netherrack"
+    ],
+    "growthTicks": 2750,
+    "display": {
+      "block": "nethers_exoticism:ramboutan_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "nethers_exoticism:ramboutan_log"
+        },
+        "minRolls": 1,
+        "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "nethers_exoticism:ramboutan"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.10,
+        "output": {
+          "item": "nethers_exoticism:ramboutan_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/occultism/otherworld.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/occultism/otherworld.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "occultism:otherworld_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "occultism:otherworld_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2750,
+    "display": {
+      "block": "occultism:otherworld_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "occultism:otherworld_log"
+        },
+        "minRolls": 1,
+        "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.10,
+        "output": {
+          "item": "occultism:otherworld_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/pizzacraft/olive.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/pizzacraft/olive.json
@@ -1,0 +1,53 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "pizzacraft:olive_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "pizzacraft:olive_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2750,
+    "display": {
+      "block": "pizzacraft:olive_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "pizzacraft:olive_log"
+        },
+        "minRolls": 1,
+        "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "pizzacraft:olive"
+      },
+      "minRolls": 2,
+      "maxRolls": 3
+    },
+    {
+        "chance": 0.10,
+        "output": {
+          "item": "pizzacraft:olive_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/pyromancer/pyrowood.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/pyromancer/pyrowood.json
@@ -1,0 +1,37 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "pyromancer:pyrowood_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "pyromancer:pyrowood_sapling"
+    },
+    "categories": [
+      "pyromossed_netherrack"
+    ],
+    "growthTicks": 2750,
+    "display": {
+      "block": "pyromancer:pyrowood_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "pyromancer:pyrowood_log"
+        },
+        "minRolls": 1,
+        "maxRolls": 2
+    },
+    {
+        "chance": 0.10,
+        "output": {
+          "item": "pyromancer:pyrowood_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/regions_unexplored/alpha.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/regions_unexplored/alpha.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "regions_unexplored:alpha_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "regions_unexplored:alpha_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "regions_unexplored:alpha_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "regions_unexplored:alpha_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.15,
+        "output": {
+          "item": "regions_unexplored:alpha_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/regions_unexplored/apple_oak.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/regions_unexplored/apple_oak.json
@@ -1,0 +1,61 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "regions_unexplored:apple_oak_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "regions_unexplored:apple_oak_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "regions_unexplored:apple_oak_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:oak_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:apple"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.15,
+      "output": {
+        "item": "minecraft:oak_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.05,
+        "output": {
+          "item": "regions_unexplored:apple_oak_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/regions_unexplored/ashen.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/regions_unexplored/ashen.json
@@ -1,0 +1,53 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "regions_unexplored:ashen_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "regions_unexplored:ashen_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "regions_unexplored:ashen_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "regions_unexplored:ashen_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:apple"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.15,
+        "output": {
+          "item": "regions_unexplored:ashen_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/regions_unexplored/bamboo.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/regions_unexplored/bamboo.json
@@ -1,0 +1,38 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "regions_unexplored:bamboo_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "regions_unexplored:bamboo_sapling"
+    },
+    "categories": [
+      "dirt",
+      "podzol"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "regions_unexplored:bamboo_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "regions_unexplored:bamboo_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+        "chance": 0.15,
+        "output": {
+          "item": "regions_unexplored:bamboo_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/regions_unexplored/baobab.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/regions_unexplored/baobab.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "regions_unexplored:baobab_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "regions_unexplored:baobab_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "regions_unexplored:baobab_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "regions_unexplored:baobab_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.15,
+        "output": {
+          "item": "regions_unexplored:baobab_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/regions_unexplored/blackwood.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/regions_unexplored/blackwood.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "regions_unexplored:blackwood_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "regions_unexplored:blackwood_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "regions_unexplored:blackwood_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "regions_unexplored:blackwood_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.15,
+        "output": {
+          "item": "regions_unexplored:blackwood_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/regions_unexplored/blue_magnolia.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/regions_unexplored/blue_magnolia.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "regions_unexplored:blue_magnolia_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "regions_unexplored:blue_magnolia_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "regions_unexplored:blue_magnolia_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "regions_unexplored:magnolia_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.15,
+        "output": {
+          "item": "regions_unexplored:blue_magnolia_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/regions_unexplored/brimwood.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/regions_unexplored/brimwood.json
@@ -1,0 +1,47 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "regions_unexplored:brimwood_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "regions_unexplored:brimwood_sapling"
+    },
+    "categories": [
+      "dirt",
+      "nether",
+      "nylium"
+    ],
+    "growthTicks": 2750,
+    "display": {
+      "block": "regions_unexplored:brimwood_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "regions_unexplored:brimwood_log"
+        },
+        "minRolls": 1,
+        "maxRolls": 2
+    },
+    {
+      "chance": 0.05,
+      "output": {
+        "item": "regions_unexplored:brimwood_log_magma"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.05,
+        "output": {
+          "item": "regions_unexplored:brimwood_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/regions_unexplored/cobalt.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/regions_unexplored/cobalt.json
@@ -1,0 +1,43 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "regions_unexplored:cobalt_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "regions_unexplored:cobalt_sapling"
+    },
+    "categories": [
+      "nether",
+      "mycotoxic_nylium",
+      "glistering_nylium",
+      "cobalt_nylium",
+      "warped_nylium",
+      "brimsprout_nylium",
+      "crimson_nylium"
+    ],
+    "growthTicks": 2750,
+    "display": {
+      "block": "regions_unexplored:cobalt_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "regions_unexplored:cobalt_log"
+        },
+        "minRolls": 1,
+        "maxRolls": 2
+    },
+    {
+        "chance": 0.10,
+        "output": {
+          "item": "regions_unexplored:cobalt_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/regions_unexplored/cypress.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/regions_unexplored/cypress.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "regions_unexplored:cypress_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "regions_unexplored:cypress_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "regions_unexplored:cypress_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "regions_unexplored:cypress_log"
+        },
+        "minRolls": 3,
+        "maxRolls": 5
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.15,
+        "output": {
+          "item": "regions_unexplored:cypress_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/regions_unexplored/dead.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/regions_unexplored/dead.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "regions_unexplored:dead_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "regions_unexplored:dead_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "regions_unexplored:dead_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "regions_unexplored:dead_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.15,
+        "output": {
+          "item": "regions_unexplored:dead_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/regions_unexplored/dead_pine.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/regions_unexplored/dead_pine.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "regions_unexplored:dead_pine_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "regions_unexplored:dead_pine_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "regions_unexplored:dead_pine_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "regions_unexplored:pine_log"
+        },
+        "minRolls": 4,
+        "maxRolls": 6
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.15,
+        "output": {
+          "item": "regions_unexplored:dead_pine_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/regions_unexplored/enchanted_birch.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/regions_unexplored/enchanted_birch.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "regions_unexplored:enchanted_birch_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "regions_unexplored:enchanted_birch_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "regions_unexplored:enchanted_birch_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "regions_unexplored:silver_birch_log"
+        },
+        "minRolls": 1,
+        "maxRolls": 3
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.05,
+        "output": {
+          "item": "regions_unexplored:enchanted_birch_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/regions_unexplored/eucalyptus.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/regions_unexplored/eucalyptus.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "regions_unexplored:eucalyptus_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "regions_unexplored:eucalyptus_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "regions_unexplored:eucalyptus_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "regions_unexplored:eucalyptus_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.15,
+        "output": {
+          "item": "regions_unexplored:eucalyptus_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/regions_unexplored/flowering_oak.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/regions_unexplored/flowering_oak.json
@@ -1,0 +1,61 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "regions_unexplored:flowering_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "regions_unexplored:flowering_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "regions_unexplored:flowering_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:oak_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:apple"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.15,
+      "output": {
+        "item": "minecraft:oak_sapling"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.05,
+        "output": {
+          "item": "regions_unexplored:flowering_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/regions_unexplored/golden_larch.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/regions_unexplored/golden_larch.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "regions_unexplored:golden_larch_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "regions_unexplored:golden_larch_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "regions_unexplored:golden_larch_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "regions_unexplored:larch_log"
+        },
+        "minRolls": 4,
+        "maxRolls": 6
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.15,
+        "output": {
+          "item": "regions_unexplored:golden_larch_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/regions_unexplored/joshua.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/regions_unexplored/joshua.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "regions_unexplored:joshua_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "regions_unexplored:joshua_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "regions_unexplored:joshua_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "regions_unexplored:joshua_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 3,
+      "maxRolls": 6
+    },
+    {
+        "chance": 0.05,
+        "output": {
+          "item": "regions_unexplored:joshua_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/regions_unexplored/kapok.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/regions_unexplored/kapok.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "regions_unexplored:kapok_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "regions_unexplored:kapok_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "regions_unexplored:kapok_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "regions_unexplored:kapok_log"
+        },
+        "minRolls": 4,
+        "maxRolls": 6
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 3,
+      "maxRolls": 4
+    },
+    {
+        "chance": 0.05,
+        "output": {
+          "item": "regions_unexplored:kapok_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/regions_unexplored/larch.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/regions_unexplored/larch.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "regions_unexplored:larch_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "regions_unexplored:larch_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "regions_unexplored:larch_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "regions_unexplored:larch_log"
+        },
+        "minRolls": 4,
+        "maxRolls": 6
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.15,
+        "output": {
+          "item": "regions_unexplored:larch_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/regions_unexplored/magnolia.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/regions_unexplored/magnolia.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "regions_unexplored:magnolia_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "regions_unexplored:magnolia_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "regions_unexplored:magnolia_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "regions_unexplored:magnolia_log"
+        },
+        "minRolls": 1,
+        "maxRolls": 3
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.05,
+        "output": {
+          "item": "regions_unexplored:magnolia_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/regions_unexplored/maple.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/regions_unexplored/maple.json
@@ -1,0 +1,53 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "regions_unexplored:maple_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "regions_unexplored:maple_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "regions_unexplored:maple_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "regions_unexplored:maple_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:apple"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.15,
+        "output": {
+          "item": "regions_unexplored:maple_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/regions_unexplored/mauve.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/regions_unexplored/mauve.json
@@ -1,0 +1,53 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "regions_unexplored:mauve_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "regions_unexplored:mauve_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "regions_unexplored:mauve_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "regions_unexplored:mauve_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:apple"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.15,
+        "output": {
+          "item": "regions_unexplored:mauve_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/regions_unexplored/orange_maple.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/regions_unexplored/orange_maple.json
@@ -1,0 +1,53 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "regions_unexplored:orange_maple_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "regions_unexplored:orange_maple_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "regions_unexplored:orange_maple_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "regions_unexplored:maple_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:apple"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.15,
+        "output": {
+          "item": "regions_unexplored:orange_maple_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/regions_unexplored/palm.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/regions_unexplored/palm.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "regions_unexplored:palm_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "regions_unexplored:palm_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "regions_unexplored:palm_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "regions_unexplored:palm_log"
+        },
+        "minRolls": 1,
+        "maxRolls": 3
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.05,
+        "output": {
+          "item": "regions_unexplored:palm_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/regions_unexplored/pine.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/regions_unexplored/pine.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "regions_unexplored:pine_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "regions_unexplored:pine_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "regions_unexplored:pine_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "regions_unexplored:pine_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.05,
+        "output": {
+          "item": "regions_unexplored:pine_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/regions_unexplored/pink_magnolia.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/regions_unexplored/pink_magnolia.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "regions_unexplored:pink_magnolia_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "regions_unexplored:pink_magnolia_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "regions_unexplored:pink_magnolia_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "regions_unexplored:magnolia_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.15,
+        "output": {
+          "item": "regions_unexplored:pink_magnolia_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/regions_unexplored/red_maple.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/regions_unexplored/red_maple.json
@@ -1,0 +1,53 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "regions_unexplored:red_maple_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "regions_unexplored:red_maple_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "regions_unexplored:red_maple_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "regions_unexplored:maple_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:apple"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.15,
+        "output": {
+          "item": "regions_unexplored:red_maple_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/regions_unexplored/redwood.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/regions_unexplored/redwood.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "regions_unexplored:redwood_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "regions_unexplored:redwood_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "regions_unexplored:redwood_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "regions_unexplored:redwood_log"
+        },
+        "minRolls": 3,
+        "maxRolls": 5
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 3,
+      "maxRolls": 5
+    },
+    {
+        "chance": 0.15,
+        "output": {
+          "item": "regions_unexplored:redwood_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/regions_unexplored/silver_birch.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/regions_unexplored/silver_birch.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "regions_unexplored:silver_birch_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "regions_unexplored:silver_birch_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "regions_unexplored:silver_birch_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "regions_unexplored:silver_birch_log"
+        },
+        "minRolls": 1,
+        "maxRolls": 3
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.15,
+        "output": {
+          "item": "regions_unexplored:silver_birch_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/regions_unexplored/small_oak.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/regions_unexplored/small_oak.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "regions_unexplored:small_oak_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "regions_unexplored:small_oak_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "regions_unexplored:small_oak_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "regions_unexplored:small_oak_log"
+        },
+        "minRolls": 1,
+        "maxRolls": 3
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.05,
+        "output": {
+          "item": "regions_unexplored:small_oak_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/regions_unexplored/socotra.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/regions_unexplored/socotra.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "regions_unexplored:socotra_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "regions_unexplored:socotra_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "regions_unexplored:socotra_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "regions_unexplored:socotra_log"
+        },
+        "minRolls": 3,
+        "maxRolls": 5
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.15,
+        "output": {
+          "item": "regions_unexplored:socotra_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/regions_unexplored/white_magnolia.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/regions_unexplored/white_magnolia.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "regions_unexplored:white_magnolia_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "regions_unexplored:white_magnolia_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "regions_unexplored:white_magnolia_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "regions_unexplored:magnolia_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.05,
+        "output": {
+          "item": "regions_unexplored:white_magnolia_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/regions_unexplored/willow.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/regions_unexplored/willow.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "regions_unexplored:willow_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "regions_unexplored:willow_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "regions_unexplored:willow_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "regions_unexplored:willow_log"
+        },
+        "minRolls": 3,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 2,
+      "maxRolls": 3
+    },
+    {
+        "chance": 0.05,
+        "output": {
+          "item": "regions_unexplored:willow_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/traverse_reforged/brown_autumnal.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/traverse_reforged/brown_autumnal.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "traverse:brown_autumnal_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "traverse:brown_autumnal_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2750,
+    "display": {
+      "block": "traverse:brown_autumnal_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:oak_log"
+        },
+        "minRolls": 1,
+        "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.10,
+        "output": {
+          "item": "traverse:brown_autumnal_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/traverse_reforged/fir.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/traverse_reforged/fir.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "traverse:fir_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "traverse:fir_sapling"
+    },
+    "categories": [
+        "dirt"
+    ],
+    "growthTicks": 2750,
+    "display": {
+      "block": "traverse:fir_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "traverse:fir_log"
+        },
+        "minRolls": 1,
+        "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.10,
+        "output": {
+          "item": "traverse:fir_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/traverse_reforged/orange_autumnal.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/traverse_reforged/orange_autumnal.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "traverse:orange_autumnal_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "traverse:orange_autumnal_sapling"
+    },
+    "categories": [
+        "dirt"
+    ],
+    "growthTicks": 2750,
+    "display": {
+      "block": "traverse:orange_autumnal_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:oak_log"
+        },
+        "minRolls": 1,
+        "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.10,
+        "output": {
+          "item": "traverse:orange_autumnal_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/traverse_reforged/red_autumnal.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/traverse_reforged/red_autumnal.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "traverse:red_autumnal_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "traverse:red_autumnal_sapling"
+    },
+    "categories": [
+        "dirt"
+    ],
+    "growthTicks": 2750,
+    "display": {
+      "block": "traverse:red_autumnal_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:dark_oak_log"
+        },
+        "minRolls": 1,
+        "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.10,
+        "output": {
+          "item": "traverse:red_autumnal_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/traverse_reforged/yellow_autumnal.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/traverse_reforged/yellow_autumnal.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "traverse:yellow_autumnal_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "traverse:yellow_autumnal_sapling"
+    },
+    "categories": [
+        "dirt"
+    ],
+    "growthTicks": 2750,
+    "display": {
+      "block": "traverse:yellow_autumnal_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "minecraft:birch_log"
+        },
+        "minRolls": 1,
+        "maxRolls": 2
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.10,
+        "output": {
+          "item": "traverse:yellow_autumnal_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/windswept/chestnut.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/windswept/chestnut.json
@@ -1,0 +1,53 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "windswept:chestnut_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "windswept:chestnut_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "windswept:chestnut_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "windswept:chestnut_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.25,
+      "output": {
+        "item": "windswept:chestnuts"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.25,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.15,
+        "output": {
+          "item": "windswept:chestnut_sapling"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanytrees/recipes/windswept/holly.json
+++ b/Common/src/main/resources/data/botanytrees/recipes/windswept/holly.json
@@ -1,0 +1,53 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "windswept:holly_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "windswept:holly_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "windswept:holly_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "windswept:holly_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+    },
+    {
+      "chance": 0.25,
+      "output": {
+        "item": "windswept:holly_berries"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+      "chance": 0.25,
+      "output": {
+        "item": "minecraft:stick"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.15,
+        "output": {
+          "item": "windswept:holly_sapling"
+        }
+      }
+    ]
+  }


### PR DESCRIPTION
The format is consistent from 1.19.2 and up, so it should work on versions like 1.20.1. The only thing you'll need to do is tweak some things (specifically, cherry trees)

If you are to accept this pull request, the following will be added to support Botany Trees:

-Added support for The Aether saplings
-Added support for Deeper and Darker saplings
-Added support for Deep Aether saplings
-Added support for Occultism saplings
-Added support for Cultural Delight saplings
-Added support for Eidolon saplings
-Added support for End's Phantasm saplings
-Added support for PizzaCraft saplings
-Fixed compat with Forbidden & Arcanus saplings. They now properly work.
-Added support for Pyromancersaplings
-Added support for The Aether: Redux saplings
-Added support for Windswept saplings
-Added support for Caupona saplings
-Added support for Good Ending saplings
-Added support for IC2 Classic saplings
-Added support for Nether's Exoticism saplings
-Added support for Traverse Reforged saplings
-Added support for Regions Unexplored saplings