### PR TITLE
Fix log type for sakura and yucca, fix category for yucca (fixes #92)

### DIFF
--- a/common/src/main/resources/data/botanytrees/recipes/biomeswevegone/white_sakura.json
+++ b/common/src/main/resources/data/botanytrees/recipes/biomeswevegone/white_sakura.json
@@ -22,7 +22,7 @@
       {
         "chance": 1.00,
         "output": {
-          "item": "biomeswevegone:white_sakura_log"
+          "item": "biomeswevegone:sakura_log"
         },
         "minRolls": 2,
         "maxRolls": 4

--- a/common/src/main/resources/data/botanytrees/recipes/biomeswevegone/yellow_sakura.json
+++ b/common/src/main/resources/data/botanytrees/recipes/biomeswevegone/yellow_sakura.json
@@ -22,7 +22,7 @@
       {
         "chance": 1.00,
         "output": {
-          "item": "biomeswevegone:yellow_sakura_log"
+          "item": "biomeswevegone:sakura_log"
         },
         "minRolls": 2,
         "maxRolls": 4

--- a/common/src/main/resources/data/botanytrees/recipes/biomeswevegone/yucca.json
+++ b/common/src/main/resources/data/botanytrees/recipes/biomeswevegone/yucca.json
@@ -12,7 +12,7 @@
       "item": "biomeswevegone:yucca_sapling"
     },
     "categories": [
-      "dirt"
+      "sand"
     ],
     "growthTicks": 2400,
     "display": {
@@ -22,7 +22,7 @@
       {
         "chance": 1.00,
         "output": {
-          "item": "biomeswevegone:yucca_log"
+          "item": "biomeswevegone:oak_log"
         },
         "minRolls": 2,
         "maxRolls": 4


### PR DESCRIPTION
This fixes the bugs I addressed in issue #92

- There is no "white_sakura_log" or "yellow_sakura_log" item in Oh the Biomes we've gone v1.3.3, but it is "sakura_log" for both of them.
- The yucca palm grows only on sand and drops of oak logs