### PR TITLE
[1.20.1] [Nether's Exoticism] pitaya, buddha's hand, and Jabuticaba logs compat

### DIFF
--- a/common/src/main/resources/data/botanytrees/recipes/nethers_exoticism/bouddha_s_hand.json
+++ b/common/src/main/resources/data/botanytrees/recipes/nethers_exoticism/bouddha_s_hand.json
@@ -1,0 +1,49 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "nethers_exoticism:bouddha_s_hand_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "nethers_exoticism:bouddha_s_hand_sapling"
+    },
+    "categories": [
+      "soul_sand"
+    ],
+    "growthTicks": 2750,
+    "display": {
+      "block": "nethers_exoticism:bouddha_s_hand_sapling"
+    },
+    "drops": [
+      {
+        "chance": 0.04,
+        "output": {
+          "item": "nethers_exoticism:bone_column"
+        }
+    },
+    {
+      "chance": 0.01,
+      "output": {
+        "item": "minecraft:bone_block"
+      }
+    },
+    {
+      "chance": 0.20,
+      "output": {
+        "item": "nethers_exoticism:bouddha_s_hand"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    },
+    {
+        "chance": 0.10,
+        "output": {
+          "item": "nethers_exoticism:bouddha_s_hand_sapling"
+        }
+      }
+    ]
+  }

--- a/common/src/main/resources/data/botanytrees/recipes/nethers_exoticism/pitaya.json
+++ b/common/src/main/resources/data/botanytrees/recipes/nethers_exoticism/pitaya.json
@@ -3,34 +3,35 @@
       {
         "type": "bookshelf:item_exists",
         "values": [
-          "nethers_exoticism:jaboticaba_sapling"
+          "nethers_exoticism:pitaya_sapling"
         ]
       }
     ],
     "type": "botanypots:crop",
     "seed": {
-      "item": "nethers_exoticism:jaboticaba_sapling"
+      "item": "nethers_exoticism:pitaya_sapling"
     },
     "categories": [
-      "blackstone"
+      "nylium",
+      "netherrack"
     ],
     "growthTicks": 2750,
     "display": {
-      "block": "nethers_exoticism:jaboticaba_sapling"
+      "block": "nethers_exoticism:pitaya_sapling"
     },
     "drops": [
       {
         "chance": 1.00,
         "output": {
-          "item": "nethers_exoticism:jaboticaba_branch_empty"
+          "item": "nethers_exoticism:pitaya_stem"
         },
-        "minRolls": 3,
-        "maxRolls": 4
+        "minRolls": 1,
+        "maxRolls": 2
     },
     {
       "chance": 0.20,
       "output": {
-        "item": "nethers_exoticism:jaboticaba"
+        "item": "nethers_exoticism:pitaya"
       },
       "minRolls": 1,
       "maxRolls": 2
@@ -38,13 +39,7 @@
     {
         "chance": 0.10,
         "output": {
-          "item": "nethers_exoticism:jaboticaba_sapling"
-        }
-    },
-    {
-      "chance": 0.01,
-      "output": {
-        "item": "nethers_exoticism:jaboticaba_branch"
+          "item": "nethers_exoticism:pitaya_sapling"
         }
       }
     ]


### PR DESCRIPTION
Added compatability recipe for pitaya, and buddha's hand (bouddha in game) since they were not previously potable while the other saplings were.

Changed jabuticaba so the wood craftable variant is dropped. Previously the logs that were given need the fruit taken off to be processed into wood.

tested for:
Nether's Exoticism 1.2.8