### PR TITLE
Added missing Biomes O' Plenty trees

### DIFF
--- a/common/src/main/resources/data/botanytrees/recipes/biomesoplenty/cypress.json
+++ b/common/src/main/resources/data/botanytrees/recipes/biomesoplenty/cypress.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "biomesoplenty:cypress_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "biomesoplenty:cypress_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "biomesoplenty:cypress_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1,
+        "output": {
+          "item": "minecraft:spruce_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+      },
+      {
+        "chance": 0.2,
+        "output": {
+          "item": "minecraft:stick"
+        },
+        "minRolls": 1,
+        "maxRolls": 2
+      },
+      {
+        "chance": 0.01,
+        "output": {
+          "item": "biomesoplenty:cypress_sapling"
+        }
+      }
+    ]
+  }

--- a/common/src/main/resources/data/botanytrees/recipes/biomesoplenty/empyreal.json
+++ b/common/src/main/resources/data/botanytrees/recipes/biomesoplenty/empyreal.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "biomesoplenty:empyreal_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "biomesoplenty:empyreal_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "biomesoplenty:empyreal_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1,
+        "output": {
+          "item": "biomesoplenty:empyreal_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+      },
+      {
+        "chance": 0.2,
+        "output": {
+          "item": "minecraft:stick"
+        },
+        "minRolls": 1,
+        "maxRolls": 2
+      },
+      {
+        "chance": 0.01,
+        "output": {
+          "item": "biomesoplenty:empyreal_sapling"
+        }
+      }
+    ]
+  }

--- a/common/src/main/resources/data/botanytrees/recipes/biomesoplenty/orange_maple.json
+++ b/common/src/main/resources/data/botanytrees/recipes/biomesoplenty/orange_maple.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "biomesoplenty:orange_maple_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "biomesoplenty:orange_maple_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "biomesoplenty:orange_maple_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1,
+        "output": {
+          "item": "biomesoplenty:maple_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+      },
+      {
+        "chance": 0.2,
+        "output": {
+          "item": "minecraft:stick"
+        },
+        "minRolls": 1,
+        "maxRolls": 2
+      },
+      {
+        "chance": 0.01,
+        "output": {
+          "item": "biomesoplenty:orange_maple_sapling"
+        }
+      }
+    ]
+  }

--- a/common/src/main/resources/data/botanytrees/recipes/biomesoplenty/pine.json
+++ b/common/src/main/resources/data/botanytrees/recipes/biomesoplenty/pine.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "biomesoplenty:pine_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "biomesoplenty:pine_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "biomesoplenty:pine_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1,
+        "output": {
+          "item": "biomesoplenty:pine_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+      },
+      {
+        "chance": 0.2,
+        "output": {
+          "item": "minecraft:stick"
+        },
+        "minRolls": 1,
+        "maxRolls": 2
+      },
+      {
+        "chance": 0.01,
+        "output": {
+          "item": "biomesoplenty:pine_sapling"
+        }
+      }
+    ]
+  }

--- a/common/src/main/resources/data/botanytrees/recipes/biomesoplenty/red_maple.json
+++ b/common/src/main/resources/data/botanytrees/recipes/biomesoplenty/red_maple.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "biomesoplenty:red_maple_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "biomesoplenty:red_maple_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "biomesoplenty:red_maple_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1,
+        "output": {
+          "item": "biomesoplenty:maple_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+      },
+      {
+        "chance": 0.2,
+        "output": {
+          "item": "minecraft:stick"
+        },
+        "minRolls": 1,
+        "maxRolls": 2
+      },
+      {
+        "chance": 0.01,
+        "output": {
+          "item": "biomesoplenty:red_maple_sapling"
+        }
+      }
+    ]
+  }

--- a/common/src/main/resources/data/botanytrees/recipes/biomesoplenty/yellow_maple.json
+++ b/common/src/main/resources/data/botanytrees/recipes/biomesoplenty/yellow_maple.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "biomesoplenty:yellow_maple_sapling"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "biomesoplenty:yellow_maple_sapling"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 2400,
+    "display": {
+      "block": "biomesoplenty:yellow_maple_sapling"
+    },
+    "drops": [
+      {
+        "chance": 1,
+        "output": {
+          "item": "biomesoplenty:maple_log"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+      },
+      {
+        "chance": 0.2,
+        "output": {
+          "item": "minecraft:stick"
+        },
+        "minRolls": 1,
+        "maxRolls": 2
+      },
+      {
+        "chance": 0.01,
+        "output": {
+          "item": "biomesoplenty:yellow_maple_sapling"
+        }
+      }
+    ]
+  }


### PR DESCRIPTION
New saplings added from newest BOP version.
```
biomesoplenty:cypress_sapling
biomesoplenty:pine_sapling
biomesoplenty:red_maple_sapling
biomesoplenty:orange_maple_sapling
biomesoplenty:yellow_maple_sapling
biomesoplenty:empyreal_sapling
```
That should be all trees to fix #81