### PR TITLE
Add recipes for Ars Elemental, Ars Nouveau, Integrated Dynamics and Malum

### DIFF
--- a/common/src/main/resources/data/botanytrees/recipe/ars_elemental/flashing_archwood.json
+++ b/common/src/main/resources/data/botanytrees/recipe/ars_elemental/flashing_archwood.json
@@ -1,0 +1,41 @@
+{
+  "bookshelf:load_conditions": [
+    {
+      "type": "bookshelf:block_exists",
+      "values": ["ars_elemental:yellow_archwood_sapling"]
+    }
+  ],
+  "type": "botanypots:crop",
+  "input": {
+    "item": "ars_elemental:yellow_archwood_sapling"
+  },
+  "soil": {
+    "tag": "botanypots:soil/dirt"
+  },
+  "grow_time": 2400,
+  "display": {
+    "type": "botanypots:aging",
+    "block": "ars_elemental:yellow_archwood_sapling"
+  },
+  "drops": [
+    {
+      "type": "botanypots:items",
+      "items": [
+        {
+          "result": {
+            "id": "ars_elemental:yellow_archwood_log"
+          },
+          "chance": 1.00,
+          "minRolls": 2,
+          "maxRolls": 4
+        },
+        {
+          "result": {
+            "id": "ars_elemental:yellow_archwood_sapling"
+          },
+          "chance": 0.05
+        }
+      ]
+    }
+  ]
+}

--- a/common/src/main/resources/data/botanytrees/recipe/ars_nouveau/blazing_archwood.json
+++ b/common/src/main/resources/data/botanytrees/recipe/ars_nouveau/blazing_archwood.json
@@ -1,0 +1,41 @@
+{
+  "bookshelf:load_conditions": [
+    {
+      "type": "bookshelf:block_exists",
+      "values": ["ars_nouveau:red_archwood_sapling"]
+    }
+  ],
+  "type": "botanypots:crop",
+  "input": {
+    "item": "ars_nouveau:red_archwood_sapling"
+  },
+  "soil": {
+    "tag": "botanypots:soil/dirt"
+  },
+  "grow_time": 2400,
+  "display": {
+    "type": "botanypots:aging",
+    "block": "ars_nouveau:red_archwood_sapling"
+  },
+  "drops": [
+    {
+      "type": "botanypots:items",
+      "items": [
+        {
+          "result": {
+            "id": "ars_nouveau:red_archwood_log"
+          },
+          "chance": 1.00,
+          "minRolls": 2,
+          "maxRolls": 4
+        },
+        {
+          "result": {
+            "id": "ars_nouveau:red_archwood_sapling"
+          },
+          "chance": 0.05
+        }
+      ]
+    }
+  ]
+}

--- a/common/src/main/resources/data/botanytrees/recipe/ars_nouveau/cascading_archwood.json
+++ b/common/src/main/resources/data/botanytrees/recipe/ars_nouveau/cascading_archwood.json
@@ -1,0 +1,41 @@
+{
+  "bookshelf:load_conditions": [
+    {
+      "type": "bookshelf:block_exists",
+      "values": ["ars_nouveau:blue_archwood_sapling"]
+    }
+  ],
+  "type": "botanypots:crop",
+  "input": {
+    "item": "ars_nouveau:blue_archwood_sapling"
+  },
+  "soil": {
+    "tag": "botanypots:soil/dirt"
+  },
+  "grow_time": 2400,
+  "display": {
+    "type": "botanypots:aging",
+    "block": "ars_nouveau:blue_archwood_sapling"
+  },
+  "drops": [
+    {
+      "type": "botanypots:items",
+      "items": [
+        {
+          "result": {
+            "id": "ars_nouveau:blue_archwood_log"
+          },
+          "chance": 1.00,
+          "minRolls": 2,
+          "maxRolls": 4
+        },
+        {
+          "result": {
+            "id": "ars_nouveau:blue_archwood_sapling"
+          },
+          "chance": 0.05
+        }
+      ]
+    }
+  ]
+}

--- a/common/src/main/resources/data/botanytrees/recipe/ars_nouveau/flourishing_archwood.json
+++ b/common/src/main/resources/data/botanytrees/recipe/ars_nouveau/flourishing_archwood.json
@@ -1,0 +1,41 @@
+{
+  "bookshelf:load_conditions": [
+    {
+      "type": "bookshelf:block_exists",
+      "values": ["ars_nouveau:green_archwood_sapling"]
+    }
+  ],
+  "type": "botanypots:crop",
+  "input": {
+    "item": "ars_nouveau:green_archwood_sapling"
+  },
+  "soil": {
+    "tag": "botanypots:soil/dirt"
+  },
+  "grow_time": 2400,
+  "display": {
+    "type": "botanypots:aging",
+    "block": "ars_nouveau:green_archwood_sapling"
+  },
+  "drops": [
+    {
+      "type": "botanypots:items",
+      "items": [
+        {
+          "result": {
+            "id": "ars_nouveau:green_archwood_log"
+          },
+          "chance": 1.00,
+          "minRolls": 2,
+          "maxRolls": 4
+        },
+        {
+          "result": {
+            "id": "ars_nouveau:green_archwood_sapling"
+          },
+          "chance": 0.05
+        }
+      ]
+    }
+  ]
+}

--- a/common/src/main/resources/data/botanytrees/recipe/ars_nouveau/vexing_archwood.json
+++ b/common/src/main/resources/data/botanytrees/recipe/ars_nouveau/vexing_archwood.json
@@ -1,0 +1,41 @@
+{
+  "bookshelf:load_conditions": [
+    {
+      "type": "bookshelf:block_exists",
+      "values": ["ars_nouveau:purple_archwood_sapling"]
+    }
+  ],
+  "type": "botanypots:crop",
+  "input": {
+    "item": "ars_nouveau:purple_archwood_sapling"
+  },
+  "soil": {
+    "tag": "botanypots:soil/dirt"
+  },
+  "grow_time": 2400,
+  "display": {
+    "type": "botanypots:aging",
+    "block": "ars_nouveau:purple_archwood_sapling"
+  },
+  "drops": [
+    {
+      "type": "botanypots:items",
+      "items": [
+        {
+          "result": {
+            "id": "ars_nouveau:purple_archwood_log"
+          },
+          "chance": 1.00,
+          "minRolls": 2,
+          "maxRolls": 4
+        },
+        {
+          "result": {
+            "id": "ars_nouveau:purple_archwood_sapling"
+          },
+          "chance": 0.05
+        }
+      ]
+    }
+  ]
+}

--- a/common/src/main/resources/data/botanytrees/recipe/integrateddynamic/menril.json
+++ b/common/src/main/resources/data/botanytrees/recipe/integrateddynamic/menril.json
@@ -1,0 +1,57 @@
+{
+  "bookshelf:load_conditions": [
+    {
+      "type": "bookshelf:block_exists",
+      "values": ["integrateddynamics:menril_sapling"]
+    }
+  ],
+  "type": "botanypots:crop",
+  "input": {
+    "item": "integrateddynamics:menril_sapling"
+  },
+  "soil": {
+    "tag": "botanypots:soil/dirt"
+  },
+  "grow_time": 2400,
+  "display": {
+    "type": "botanypots:aging",
+    "block": "integrateddynamics:menril_sapling"
+  },
+  "drops": [
+    {
+      "type": "botanypots:items",
+      "items": [
+        {
+          "result": {
+            "id": "integrateddynamics:menril_log"
+          },
+          "chance": 1.00,
+          "minRolls": 2,
+          "maxRolls": 4
+        },
+        {
+          "result": {
+            "id": "minecraft:stick"
+          },
+          "chance": 0.25,
+          "minRolls": 1,
+          "maxRolls": 2
+        },
+        {
+          "result": {
+            "id": "integrateddynamics:menril_berries"
+          },
+          "chance": 0.25,
+          "minRolls": 1,
+          "maxRolls": 2
+        },
+        {
+          "result": {
+            "id": "integrateddynamics:menril_sapling"
+          },
+          "chance": 0.01
+        }
+      ]
+    }
+  ]
+}

--- a/common/src/main/resources/data/botanytrees/recipe/malum/azure_runewood.json
+++ b/common/src/main/resources/data/botanytrees/recipe/malum/azure_runewood.json
@@ -1,0 +1,57 @@
+{
+  "bookshelf:load_conditions": [
+    {
+      "type": "bookshelf:block_exists",
+      "values": ["malum:azure_runewood_sapling"]
+    }
+  ],
+  "type": "botanypots:crop",
+  "input": {
+    "item": "malum:azure_runewood_sapling"
+  },
+  "soil": {
+    "tag": "botanypots:soil/dirt"
+  },
+  "grow_time": 2400,
+  "display": {
+    "type": "botanypots:aging",
+    "block": "malum:azure_runewood_sapling"
+  },
+  "drops": [
+    {
+      "type": "botanypots:items",
+      "items": [
+        {
+          "result": {
+            "id": "malum:runewood_log"
+          },
+          "chance": 0.33,
+          "minRolls": 2,
+          "maxRolls": 4
+        },
+        {
+          "result": {
+            "id": "minecraft:stick"
+          },
+          "chance": 0.20,
+          "minRolls": 1,
+          "maxRolls": 2
+        },
+        {
+          "result": {
+            "id": "malum:exposed_runewood_log"
+          },
+          "chance": 0.33,
+          "minRolls": 1,
+          "maxRolls": 2
+        },
+        {
+          "result": {
+            "id": "malum:azure_runewood_sapling"
+          },
+          "chance": 0.01
+        }
+      ]
+    }
+  ]
+}

--- a/common/src/main/resources/data/botanytrees/recipe/malum/runewood.json
+++ b/common/src/main/resources/data/botanytrees/recipe/malum/runewood.json
@@ -1,0 +1,57 @@
+{
+  "bookshelf:load_conditions": [
+    {
+      "type": "bookshelf:block_exists",
+      "values": ["malum:runewood_sapling"]
+    }
+  ],
+  "type": "botanypots:crop",
+  "input": {
+    "item": "malum:runewood_sapling"
+  },
+  "soil": {
+    "tag": "botanypots:soil/dirt"
+  },
+  "grow_time": 2400,
+  "display": {
+    "type": "botanypots:aging",
+    "block": "malum:runewood_sapling"
+  },
+  "drops": [
+    {
+      "type": "botanypots:items",
+      "items": [
+        {
+          "result": {
+            "id": "malum:runewood_log"
+          },
+          "chance": 0.33,
+          "minRolls": 2,
+          "maxRolls": 4
+        },
+        {
+          "result": {
+            "id": "minecraft:stick"
+          },
+          "chance": 0.20,
+          "minRolls": 1,
+          "maxRolls": 2
+        },
+        {
+          "result": {
+            "id": "malum:exposed_runewood_log"
+          },
+          "chance": 0.33,
+          "minRolls": 1,
+          "maxRolls": 2
+        },
+        {
+          "result": {
+            "id": "malum:runewood_sapling"
+          },
+          "chance": 0.01
+        }
+      ]
+    }
+  ]
+}

--- a/common/src/main/resources/data/botanytrees/recipe/malum/soulwood.json
+++ b/common/src/main/resources/data/botanytrees/recipe/malum/soulwood.json
@@ -1,0 +1,65 @@
+{
+  "bookshelf:load_conditions": [
+    {
+      "type": "bookshelf:block_exists",
+      "values": ["malum:soulwood_sapling"]
+    }
+  ],
+  "type": "botanypots:crop",
+  "input": {
+    "item": "malum:soulwood_sapling"
+  },
+  "soil": {
+    "tag": "botanypots:soil/dirt"
+  },
+  "grow_time": 2400,
+  "display": {
+    "type": "botanypots:aging",
+    "block": "malum:soulwood_sapling"
+  },
+  "drops": [
+    {
+      "type": "botanypots:items",
+      "items": [
+        {
+          "result": {
+            "id": "malum:soulwood_log"
+          },
+          "chance": 0.33,
+          "minRolls": 2,
+          "maxRolls": 4
+        },
+        {
+          "result": {
+            "id": "minecraft:stick"
+          },
+          "chance": 0.20,
+          "minRolls": 1,
+          "maxRolls": 2
+        },
+        {
+          "result": {
+            "id": "malum:exposed_soulwood_log"
+          },
+          "chance": 0.33,
+          "minRolls": 1,
+          "maxRolls": 2
+        },
+        {
+          "result": {
+            "id": "malum:blighted_gunk"
+          },
+          "chance": 0.25,
+          "minRolls": 1,
+          "maxRolls": 2
+        },
+        {
+          "result": {
+            "id": "malum:soulwood_sapling"
+          },
+          "chance": 0.01
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Adds drop JSONs for Botany Trees integration for the following mod trees:

- Ars Elemental
- Ars Nouveau
- Integrated Dynamics
- Malum

Notes:

- Everything was tested locally with no issues observed.
- AllTheModium trees were not included because the saplings aren’t obtainable in survival by the looks of things and show texture issues in Botany Pots.
- Leaf block loot pools for shears have **not yet been added**, but I can look into this in a follow-up PR.
- If acceptable, I’m happy to add the remaining modded trees in a future PR.