### PR TITLE
1.21.1 Biomes O Plenty + Nature's Spirit support

### DIFF
--- a/common/src/main/resources/data/botanytrees/loot_table/tree_drops/biomesoplenty/cypress.json
+++ b/common/src/main/resources/data/botanytrees/loot_table/tree_drops/biomesoplenty/cypress.json
@@ -1,0 +1,72 @@
+{
+	"type": "minecraft:block",
+	"pools": [
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"name": "minecraft:spruce_log",
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 4,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					]
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:random_chance",
+							"chance": 0.05
+						}
+					],
+					"name": "biomesoplenty:cypress_sapling"
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:match_tool",
+							"predicate": {
+								"items": "minecraft:shears"
+							}
+						}
+					],
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 3,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					],
+					"name": "biomesoplenty:cypress_leaves"
+				}
+			],
+			"rolls": 1.0
+		}
+	],
+	"random_sequence": "botanytrees:biomesoplenty/cypress"
+}

--- a/common/src/main/resources/data/botanytrees/loot_table/tree_drops/biomesoplenty/dead.json
+++ b/common/src/main/resources/data/botanytrees/loot_table/tree_drops/biomesoplenty/dead.json
@@ -1,0 +1,72 @@
+{
+	"type": "minecraft:block",
+	"pools": [
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"name": "biomesoplenty:dead_log",
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 4,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					]
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:random_chance",
+							"chance": 0.05
+						}
+					],
+					"name": "biomesoplenty:dead_sapling"
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:match_tool",
+							"predicate": {
+								"items": "minecraft:shears"
+							}
+						}
+					],
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 3,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					],
+					"name": "biomesoplenty:dead_leaves"
+				}
+			],
+			"rolls": 1.0
+		}
+	],
+	"random_sequence": "botanytrees:biomesoplenty/cypress"
+}

--- a/common/src/main/resources/data/botanytrees/loot_table/tree_drops/biomesoplenty/empyreal.json
+++ b/common/src/main/resources/data/botanytrees/loot_table/tree_drops/biomesoplenty/empyreal.json
@@ -1,0 +1,72 @@
+{
+	"type": "minecraft:block",
+	"pools": [
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"name": "biomesoplenty:empyreal_log",
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 4,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					]
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:random_chance",
+							"chance": 0.05
+						}
+					],
+					"name": "biomesoplenty:empyreal_sapling"
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:match_tool",
+							"predicate": {
+								"items": "minecraft:shears"
+							}
+						}
+					],
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 3,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					],
+					"name": "biomesoplenty:empyreal_leaves"
+				}
+			],
+			"rolls": 1.0
+		}
+	],
+	"random_sequence": "botanytrees:biomesoplenty/empyreal"
+}

--- a/common/src/main/resources/data/botanytrees/loot_table/tree_drops/biomesoplenty/fir.json
+++ b/common/src/main/resources/data/botanytrees/loot_table/tree_drops/biomesoplenty/fir.json
@@ -1,0 +1,72 @@
+{
+	"type": "minecraft:block",
+	"pools": [
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"name": "biomesoplenty:fir_log",
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 4,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					]
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:random_chance",
+							"chance": 0.05
+						}
+					],
+					"name": "biomesoplenty:fir_sapling"
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:match_tool",
+							"predicate": {
+								"items": "minecraft:shears"
+							}
+						}
+					],
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 3,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					],
+					"name": "biomesoplenty:fir_leaves"
+				}
+			],
+			"rolls": 1.0
+		}
+	],
+	"random_sequence": "botanytrees:biomesoplenty/fir"
+}

--- a/common/src/main/resources/data/botanytrees/loot_table/tree_drops/biomesoplenty/flowering_oak.json
+++ b/common/src/main/resources/data/botanytrees/loot_table/tree_drops/biomesoplenty/flowering_oak.json
@@ -1,0 +1,117 @@
+{
+	"type": "minecraft:block",
+	"pools": [
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"name": "minecraft:oak_log",
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 4,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					]
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:random_chance",
+							"chance": 0.05
+						}
+					],
+					"name": "biomesoplenty:flowering_oak_sapling"
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:random_chance",
+							"chance": 0.05
+						}
+					],
+					"name": "minecraft:oak_sapling"
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:match_tool",
+							"predicate": {
+								"items": "minecraft:shears"
+							}
+						}
+					],
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 3,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					],
+					"name": "biomesoplenty:flowering_oak_leaves"
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:match_tool",
+							"predicate": {
+								"items": "minecraft:shears"
+							}
+						}
+					],
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 3,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					],
+					"name": "minecraft:oak_leaves"
+				}
+			],
+			"rolls": 1.0
+		}
+	],
+	"random_sequence": "botanytrees:biomesoplenty/flowering_oak"
+}

--- a/common/src/main/resources/data/botanytrees/loot_table/tree_drops/biomesoplenty/hellbark.json
+++ b/common/src/main/resources/data/botanytrees/loot_table/tree_drops/biomesoplenty/hellbark.json
@@ -1,0 +1,72 @@
+{
+	"type": "minecraft:block",
+	"pools": [
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"name": "biomesoplenty:hellbark_log",
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 4,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					]
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:random_chance",
+							"chance": 0.05
+						}
+					],
+					"name": "biomesoplenty:hellbark_sapling"
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:match_tool",
+							"predicate": {
+								"items": "minecraft:shears"
+							}
+						}
+					],
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 3,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					],
+					"name": "biomesoplenty:hellbark_leaves"
+				}
+			],
+			"rolls": 1.0
+		}
+	],
+	"random_sequence": "botanytrees:biomesoplenty/hellbark"
+}

--- a/common/src/main/resources/data/botanytrees/loot_table/tree_drops/biomesoplenty/jacaranda.json
+++ b/common/src/main/resources/data/botanytrees/loot_table/tree_drops/biomesoplenty/jacaranda.json
@@ -1,0 +1,72 @@
+{
+	"type": "minecraft:block",
+	"pools": [
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"name": "biomesoplenty:jacaranda_log",
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 4,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					]
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:random_chance",
+							"chance": 0.05
+						}
+					],
+					"name": "biomesoplenty:jacaranda_sapling"
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:match_tool",
+							"predicate": {
+								"items": "minecraft:shears"
+							}
+						}
+					],
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 3,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					],
+					"name": "biomesoplenty:jacaranda_leaves"
+				}
+			],
+			"rolls": 1.0
+		}
+	],
+	"random_sequence": "botanytrees:biomesoplenty/jacaranda"
+}

--- a/common/src/main/resources/data/botanytrees/loot_table/tree_drops/biomesoplenty/magic.json
+++ b/common/src/main/resources/data/botanytrees/loot_table/tree_drops/biomesoplenty/magic.json
@@ -1,0 +1,72 @@
+{
+	"type": "minecraft:block",
+	"pools": [
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"name": "biomesoplenty:magic_log",
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 4,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					]
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:random_chance",
+							"chance": 0.05
+						}
+					],
+					"name": "biomesoplenty:magic_sapling"
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:match_tool",
+							"predicate": {
+								"items": "minecraft:shears"
+							}
+						}
+					],
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 3,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					],
+					"name": "biomesoplenty:magic_leaves"
+				}
+			],
+			"rolls": 1.0
+		}
+	],
+	"random_sequence": "botanytrees:biomesoplenty/magic"
+}

--- a/common/src/main/resources/data/botanytrees/loot_table/tree_drops/biomesoplenty/mahogany.json
+++ b/common/src/main/resources/data/botanytrees/loot_table/tree_drops/biomesoplenty/mahogany.json
@@ -1,0 +1,72 @@
+{
+	"type": "minecraft:block",
+	"pools": [
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"name": "biomesoplenty:mahogany_log",
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 4,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					]
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:random_chance",
+							"chance": 0.05
+						}
+					],
+					"name": "biomesoplenty:mahogany_sapling"
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:match_tool",
+							"predicate": {
+								"items": "minecraft:shears"
+							}
+						}
+					],
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 3,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					],
+					"name": "biomesoplenty:mahogany_leaves"
+				}
+			],
+			"rolls": 1.0
+		}
+	],
+	"random_sequence": "botanytrees:biomesoplenty/mahogany"
+}

--- a/common/src/main/resources/data/botanytrees/loot_table/tree_drops/biomesoplenty/orange_maple.json
+++ b/common/src/main/resources/data/botanytrees/loot_table/tree_drops/biomesoplenty/orange_maple.json
@@ -1,0 +1,72 @@
+{
+	"type": "minecraft:block",
+	"pools": [
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"name": "biomesoplenty:maple_log",
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 4,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					]
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:random_chance",
+							"chance": 0.05
+						}
+					],
+					"name": "biomesoplenty:orange_maple_sapling"
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:match_tool",
+							"predicate": {
+								"items": "minecraft:shears"
+							}
+						}
+					],
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 3,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					],
+					"name": "biomesoplenty:orange_maple_leaves"
+				}
+			],
+			"rolls": 1.0
+		}
+	],
+	"random_sequence": "botanytrees:biomesoplenty/orange_maple"
+}

--- a/common/src/main/resources/data/botanytrees/loot_table/tree_drops/biomesoplenty/origin.json
+++ b/common/src/main/resources/data/botanytrees/loot_table/tree_drops/biomesoplenty/origin.json
@@ -1,0 +1,88 @@
+{
+	"type": "minecraft:block",
+	"pools": [
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"name": "minecraft:oak_log",
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 4,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					]
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:random_chance",
+							"chance": 0.05
+						}
+					],
+					"name": "biomesoplenty:origin_sapling"
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:random_chance",
+							"chance": 0.05
+						}
+					],
+					"name": "minecraft:apple"
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:match_tool",
+							"predicate": {
+								"items": "minecraft:shears"
+							}
+						}
+					],
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 3,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					],
+					"name": "biomesoplenty:origin_leaves"
+				}
+			],
+			"rolls": 1.0
+		}
+	],
+	"random_sequence": "botanytrees:biomesoplenty/origin"
+}

--- a/common/src/main/resources/data/botanytrees/loot_table/tree_drops/biomesoplenty/palm.json
+++ b/common/src/main/resources/data/botanytrees/loot_table/tree_drops/biomesoplenty/palm.json
@@ -1,0 +1,72 @@
+{
+	"type": "minecraft:block",
+	"pools": [
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"name": "biomesoplenty:palm_log",
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 4,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					]
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:random_chance",
+							"chance": 0.05
+						}
+					],
+					"name": "biomesoplenty:palm_sapling"
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:match_tool",
+							"predicate": {
+								"items": "minecraft:shears"
+							}
+						}
+					],
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 3,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					],
+					"name": "biomesoplenty:palm_leaves"
+				}
+			],
+			"rolls": 1.0
+		}
+	],
+	"random_sequence": "botanytrees:biomesoplenty/palm"
+}

--- a/common/src/main/resources/data/botanytrees/loot_table/tree_drops/biomesoplenty/pine.json
+++ b/common/src/main/resources/data/botanytrees/loot_table/tree_drops/biomesoplenty/pine.json
@@ -1,0 +1,72 @@
+{
+	"type": "minecraft:block",
+	"pools": [
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"name": "biomesoplenty:pine_log",
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 4,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					]
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:random_chance",
+							"chance": 0.05
+						}
+					],
+					"name": "biomesoplenty:pine_sapling"
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:match_tool",
+							"predicate": {
+								"items": "minecraft:shears"
+							}
+						}
+					],
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 3,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					],
+					"name": "biomesoplenty:pine_leaves"
+				}
+			],
+			"rolls": 1.0
+		}
+	],
+	"random_sequence": "botanytrees:biomesoplenty/pine"
+}

--- a/common/src/main/resources/data/botanytrees/loot_table/tree_drops/biomesoplenty/rainbow_birch.json
+++ b/common/src/main/resources/data/botanytrees/loot_table/tree_drops/biomesoplenty/rainbow_birch.json
@@ -1,0 +1,72 @@
+{
+	"type": "minecraft:block",
+	"pools": [
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"name": "minecraft:birch_log",
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 4,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					]
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:random_chance",
+							"chance": 0.05
+						}
+					],
+					"name": "biomesoplenty:rainbow_birch_sapling"
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:match_tool",
+							"predicate": {
+								"items": "minecraft:shears"
+							}
+						}
+					],
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 3,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					],
+					"name": "biomesoplenty:rainbow_birch_leaves"
+				}
+			],
+			"rolls": 1.0
+		}
+	],
+	"random_sequence": "botanytrees:biomesoplenty/rainbow_birch"
+}

--- a/common/src/main/resources/data/botanytrees/loot_table/tree_drops/biomesoplenty/red_maple.json
+++ b/common/src/main/resources/data/botanytrees/loot_table/tree_drops/biomesoplenty/red_maple.json
@@ -1,0 +1,72 @@
+{
+	"type": "minecraft:block",
+	"pools": [
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"name": "biomesoplenty:maple_log",
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 4,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					]
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:random_chance",
+							"chance": 0.05
+						}
+					],
+					"name": "biomesoplenty:red_maple_sapling"
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:match_tool",
+							"predicate": {
+								"items": "minecraft:shears"
+							}
+						}
+					],
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 3,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					],
+					"name": "biomesoplenty:red_maple_leaves"
+				}
+			],
+			"rolls": 1.0
+		}
+	],
+	"random_sequence": "botanytrees:biomesoplenty/red_maple"
+}

--- a/common/src/main/resources/data/botanytrees/loot_table/tree_drops/biomesoplenty/redwood.json
+++ b/common/src/main/resources/data/botanytrees/loot_table/tree_drops/biomesoplenty/redwood.json
@@ -1,0 +1,72 @@
+{
+	"type": "minecraft:block",
+	"pools": [
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"name": "biomesoplenty:redwood_log",
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 4,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					]
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:random_chance",
+							"chance": 0.05
+						}
+					],
+					"name": "biomesoplenty:redwood_sapling"
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:match_tool",
+							"predicate": {
+								"items": "minecraft:shears"
+							}
+						}
+					],
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 3,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					],
+					"name": "biomesoplenty:redwood_leaves"
+				}
+			],
+			"rolls": 1.0
+		}
+	],
+	"random_sequence": "botanytrees:biomesoplenty/redwood"
+}

--- a/common/src/main/resources/data/botanytrees/loot_table/tree_drops/biomesoplenty/snowblossom.json
+++ b/common/src/main/resources/data/botanytrees/loot_table/tree_drops/biomesoplenty/snowblossom.json
@@ -1,0 +1,72 @@
+{
+	"type": "minecraft:block",
+	"pools": [
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"name": "minecraft:cherry_log",
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 4,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					]
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:random_chance",
+							"chance": 0.05
+						}
+					],
+					"name": "biomesoplenty:snowblossom_sapling"
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:match_tool",
+							"predicate": {
+								"items": "minecraft:shears"
+							}
+						}
+					],
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 3,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					],
+					"name": "biomesoplenty:snowblossom_leaves"
+				}
+			],
+			"rolls": 1.0
+		}
+	],
+	"random_sequence": "botanytrees:biomesoplenty/snowblossom"
+}

--- a/common/src/main/resources/data/botanytrees/loot_table/tree_drops/biomesoplenty/umbran.json
+++ b/common/src/main/resources/data/botanytrees/loot_table/tree_drops/biomesoplenty/umbran.json
@@ -1,0 +1,72 @@
+{
+	"type": "minecraft:block",
+	"pools": [
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"name": "biomesoplenty:umbran_log",
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 4,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					]
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:random_chance",
+							"chance": 0.05
+						}
+					],
+					"name": "biomesoplenty:umbran_sapling"
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:match_tool",
+							"predicate": {
+								"items": "minecraft:shears"
+							}
+						}
+					],
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 3,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					],
+					"name": "biomesoplenty:umbran_leaves"
+				}
+			],
+			"rolls": 1.0
+		}
+	],
+	"random_sequence": "botanytrees:biomesoplenty/umbran"
+}

--- a/common/src/main/resources/data/botanytrees/loot_table/tree_drops/biomesoplenty/willow.json
+++ b/common/src/main/resources/data/botanytrees/loot_table/tree_drops/biomesoplenty/willow.json
@@ -1,0 +1,72 @@
+{
+	"type": "minecraft:block",
+	"pools": [
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"name": "biomesoplenty:willow_log",
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 4,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					]
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:random_chance",
+							"chance": 0.05
+						}
+					],
+					"name": "biomesoplenty:willow_sapling"
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:match_tool",
+							"predicate": {
+								"items": "minecraft:shears"
+							}
+						}
+					],
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 3,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					],
+					"name": "biomesoplenty:willow_leaves"
+				}
+			],
+			"rolls": 1.0
+		}
+	],
+	"random_sequence": "botanytrees:biomesoplenty/willow"
+}

--- a/common/src/main/resources/data/botanytrees/loot_table/tree_drops/biomesoplenty/yellow_maple.json
+++ b/common/src/main/resources/data/botanytrees/loot_table/tree_drops/biomesoplenty/yellow_maple.json
@@ -1,0 +1,72 @@
+{
+	"type": "minecraft:block",
+	"pools": [
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"name": "biomesoplenty:maple_log",
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 4,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					]
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:random_chance",
+							"chance": 0.05
+						}
+					],
+					"name": "biomesoplenty:yellow_maple_sapling"
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:match_tool",
+							"predicate": {
+								"items": "minecraft:shears"
+							}
+						}
+					],
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 3,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					],
+					"name": "biomesoplenty:yellow_maple_leaves"
+				}
+			],
+			"rolls": 1.0
+		}
+	],
+	"random_sequence": "botanytrees:biomesoplenty/yellow_maple"
+}

--- a/common/src/main/resources/data/botanytrees/loot_table/tree_drops/natures_spirit/aspen.json
+++ b/common/src/main/resources/data/botanytrees/loot_table/tree_drops/natures_spirit/aspen.json
@@ -1,0 +1,72 @@
+{
+	"type": "minecraft:block",
+	"pools": [
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"name": "natures_spirit:aspen_log",
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 4,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					]
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:random_chance",
+							"chance": 0.05
+						}
+					],
+					"name": "natures_spirit:aspen_sapling"
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:match_tool",
+							"predicate": {
+								"items": "minecraft:shears"
+							}
+						}
+					],
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 3,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					],
+					"name": "natures_spirit:aspen_leaves"
+				}
+			],
+			"rolls": 1.0
+		}
+	],
+	"random_sequence": "botanytrees:natures_spirit/aspen"
+}

--- a/common/src/main/resources/data/botanytrees/loot_table/tree_drops/natures_spirit/blue_wisteria.json
+++ b/common/src/main/resources/data/botanytrees/loot_table/tree_drops/natures_spirit/blue_wisteria.json
@@ -1,0 +1,159 @@
+{
+	"type": "minecraft:block",
+	"pools": [
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"name": "natures_spirit:wisteria_log",
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 4,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					]
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:random_chance",
+							"chance": 0.05
+						}
+					],
+					"name": "natures_spirit:blue_wisteria_sapling"
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:match_tool",
+							"predicate": {
+								"items": "minecraft:shears"
+							}
+						}
+					],
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 3,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					],
+					"name": "natures_spirit:blue_wisteria_leaves"
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:match_tool",
+							"predicate": {
+								"items": "minecraft:shears"
+							}
+						}
+					],
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 3,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					],
+					"name": "natures_spirit:part_blue_wisteria_leaves"
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:match_tool",
+							"predicate": {
+								"items": "minecraft:shears"
+							}
+						}
+					],
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 3,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					],
+					"name": "natures_spirit:wisteria_leaves"
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:match_tool",
+							"predicate": {
+								"items": "minecraft:shears"
+							}
+						}
+					],
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 3,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					],
+					"name": "natures_spirit:blue_wisteria_vines"
+				}
+			],
+			"rolls": 1.0
+		}
+	],
+	"random_sequence": "botanytrees:natures_spirit/blue_wisteria"
+}

--- a/common/src/main/resources/data/botanytrees/loot_table/tree_drops/natures_spirit/cedar.json
+++ b/common/src/main/resources/data/botanytrees/loot_table/tree_drops/natures_spirit/cedar.json
@@ -1,0 +1,72 @@
+{
+	"type": "minecraft:block",
+	"pools": [
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"name": "natures_spirit:cedar_log",
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 4,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					]
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:random_chance",
+							"chance": 0.05
+						}
+					],
+					"name": "natures_spirit:cedar_sapling"
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:match_tool",
+							"predicate": {
+								"items": "minecraft:shears"
+							}
+						}
+					],
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 3,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					],
+					"name": "natures_spirit:cedar_leaves"
+				}
+			],
+			"rolls": 1.0
+		}
+	],
+	"random_sequence": "botanytrees:natures_spirit/cedar"
+}

--- a/common/src/main/resources/data/botanytrees/loot_table/tree_drops/natures_spirit/cypress.json
+++ b/common/src/main/resources/data/botanytrees/loot_table/tree_drops/natures_spirit/cypress.json
@@ -1,0 +1,72 @@
+{
+	"type": "minecraft:block",
+	"pools": [
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"name": "natures_spirit:cypress_log",
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 4,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					]
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:random_chance",
+							"chance": 0.05
+						}
+					],
+					"name": "natures_spirit:cypress_sapling"
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:match_tool",
+							"predicate": {
+								"items": "minecraft:shears"
+							}
+						}
+					],
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 3,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					],
+					"name": "natures_spirit:cypress_leaves"
+				}
+			],
+			"rolls": 1.0
+		}
+	],
+	"random_sequence": "botanytrees:natures_spirit/cypress"
+}

--- a/common/src/main/resources/data/botanytrees/loot_table/tree_drops/natures_spirit/fir.json
+++ b/common/src/main/resources/data/botanytrees/loot_table/tree_drops/natures_spirit/fir.json
@@ -1,0 +1,72 @@
+{
+	"type": "minecraft:block",
+	"pools": [
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"name": "natures_spirit:fir_log",
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 4,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					]
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:random_chance",
+							"chance": 0.05
+						}
+					],
+					"name": "natures_spirit:fir_sapling"
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:match_tool",
+							"predicate": {
+								"items": "minecraft:shears"
+							}
+						}
+					],
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 3,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					],
+					"name": "natures_spirit:fir_leaves"
+				}
+			],
+			"rolls": 1.0
+		}
+	],
+	"random_sequence": "botanytrees:natures_spirit/fir"
+}

--- a/common/src/main/resources/data/botanytrees/loot_table/tree_drops/natures_spirit/ghaf.json
+++ b/common/src/main/resources/data/botanytrees/loot_table/tree_drops/natures_spirit/ghaf.json
@@ -1,0 +1,72 @@
+{
+	"type": "minecraft:block",
+	"pools": [
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"name": "natures_spirit:ghaf_log",
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 4,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					]
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:random_chance",
+							"chance": 0.05
+						}
+					],
+					"name": "natures_spirit:ghaf_sapling"
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:match_tool",
+							"predicate": {
+								"items": "minecraft:shears"
+							}
+						}
+					],
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 3,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					],
+					"name": "natures_spirit:ghaf_leaves"
+				}
+			],
+			"rolls": 1.0
+		}
+	],
+	"random_sequence": "botanytrees:natures_spirit/ghaf"
+}

--- a/common/src/main/resources/data/botanytrees/loot_table/tree_drops/natures_spirit/joshua.json
+++ b/common/src/main/resources/data/botanytrees/loot_table/tree_drops/natures_spirit/joshua.json
@@ -1,0 +1,72 @@
+{
+	"type": "minecraft:block",
+	"pools": [
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"name": "natures_spirit:joshua_log",
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 4,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					]
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:random_chance",
+							"chance": 0.05
+						}
+					],
+					"name": "natures_spirit:joshua_sapling"
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:match_tool",
+							"predicate": {
+								"items": "minecraft:shears"
+							}
+						}
+					],
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 3,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					],
+					"name": "natures_spirit:joshua_leaves"
+				}
+			],
+			"rolls": 1.0
+		}
+	],
+	"random_sequence": "botanytrees:natures_spirit/joshua"
+}

--- a/common/src/main/resources/data/botanytrees/loot_table/tree_drops/natures_spirit/larch.json
+++ b/common/src/main/resources/data/botanytrees/loot_table/tree_drops/natures_spirit/larch.json
@@ -1,0 +1,72 @@
+{
+	"type": "minecraft:block",
+	"pools": [
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"name": "natures_spirit:larch_log",
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 4,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					]
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:random_chance",
+							"chance": 0.05
+						}
+					],
+					"name": "natures_spirit:larch_sapling"
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:match_tool",
+							"predicate": {
+								"items": "minecraft:shears"
+							}
+						}
+					],
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 3,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					],
+					"name": "natures_spirit:larch_leaves"
+				}
+			],
+			"rolls": 1.0
+		}
+	],
+	"random_sequence": "botanytrees:natures_spirit/larch"
+}

--- a/common/src/main/resources/data/botanytrees/loot_table/tree_drops/natures_spirit/mahogany.json
+++ b/common/src/main/resources/data/botanytrees/loot_table/tree_drops/natures_spirit/mahogany.json
@@ -1,0 +1,72 @@
+{
+	"type": "minecraft:block",
+	"pools": [
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"name": "natures_spirit:mahogany_log",
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 4,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					]
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:random_chance",
+							"chance": 0.05
+						}
+					],
+					"name": "natures_spirit:mahogany_sapling"
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:match_tool",
+							"predicate": {
+								"items": "minecraft:shears"
+							}
+						}
+					],
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 3,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					],
+					"name": "natures_spirit:mahogany_leaves"
+				}
+			],
+			"rolls": 1.0
+		}
+	],
+	"random_sequence": "botanytrees:natures_spirit/mahogany"
+}

--- a/common/src/main/resources/data/botanytrees/loot_table/tree_drops/natures_spirit/olive.json
+++ b/common/src/main/resources/data/botanytrees/loot_table/tree_drops/natures_spirit/olive.json
@@ -1,0 +1,72 @@
+{
+	"type": "minecraft:block",
+	"pools": [
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"name": "natures_spirit:olive_log",
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 4,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					]
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:random_chance",
+							"chance": 0.05
+						}
+					],
+					"name": "natures_spirit:olive_sapling"
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:match_tool",
+							"predicate": {
+								"items": "minecraft:shears"
+							}
+						}
+					],
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 3,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					],
+					"name": "natures_spirit:olive_leaves"
+				}
+			],
+			"rolls": 1.0
+		}
+	],
+	"random_sequence": "botanytrees:natures_spirit/olive"
+}

--- a/common/src/main/resources/data/botanytrees/loot_table/tree_drops/natures_spirit/orange_maple.json
+++ b/common/src/main/resources/data/botanytrees/loot_table/tree_drops/natures_spirit/orange_maple.json
@@ -1,0 +1,72 @@
+{
+	"type": "minecraft:block",
+	"pools": [
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"name": "natures_spirit:maple_log",
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 4,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					]
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:random_chance",
+							"chance": 0.05
+						}
+					],
+					"name": "natures_spirit:orange_maple_sapling"
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:match_tool",
+							"predicate": {
+								"items": "minecraft:shears"
+							}
+						}
+					],
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 3,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					],
+					"name": "natures_spirit:orange_maple_leaves"
+				}
+			],
+			"rolls": 1.0
+		}
+	],
+	"random_sequence": "botanytrees:natures_spirit/orange_maple"
+}

--- a/common/src/main/resources/data/botanytrees/loot_table/tree_drops/natures_spirit/palo_verde.json
+++ b/common/src/main/resources/data/botanytrees/loot_table/tree_drops/natures_spirit/palo_verde.json
@@ -1,0 +1,72 @@
+{
+	"type": "minecraft:block",
+	"pools": [
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"name": "natures_spirit:palo_verde_log",
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 4,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					]
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:random_chance",
+							"chance": 0.05
+						}
+					],
+					"name": "natures_spirit:palo_verde_sapling"
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:match_tool",
+							"predicate": {
+								"items": "minecraft:shears"
+							}
+						}
+					],
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 3,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					],
+					"name": "natures_spirit:palo_verde_leaves"
+				}
+			],
+			"rolls": 1.0
+		}
+	],
+	"random_sequence": "botanytrees:natures_spirit/palo_verde"
+}

--- a/common/src/main/resources/data/botanytrees/loot_table/tree_drops/natures_spirit/pink_wisteria.json
+++ b/common/src/main/resources/data/botanytrees/loot_table/tree_drops/natures_spirit/pink_wisteria.json
@@ -1,0 +1,159 @@
+{
+	"type": "minecraft:block",
+	"pools": [
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"name": "natures_spirit:wisteria_log",
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 4,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					]
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:random_chance",
+							"chance": 0.05
+						}
+					],
+					"name": "natures_spirit:pink_wisteria_sapling"
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:match_tool",
+							"predicate": {
+								"items": "minecraft:shears"
+							}
+						}
+					],
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 3,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					],
+					"name": "natures_spirit:pink_wisteria_leaves"
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:match_tool",
+							"predicate": {
+								"items": "minecraft:shears"
+							}
+						}
+					],
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 3,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					],
+					"name": "natures_spirit:part_pink_wisteria_leaves"
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:match_tool",
+							"predicate": {
+								"items": "minecraft:shears"
+							}
+						}
+					],
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 3,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					],
+					"name": "natures_spirit:wisteria_leaves"
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:match_tool",
+							"predicate": {
+								"items": "minecraft:shears"
+							}
+						}
+					],
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 3,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					],
+					"name": "natures_spirit:pink_wisteria_vines"
+				}
+			],
+			"rolls": 1.0
+		}
+	],
+	"random_sequence": "botanytrees:natures_spirit/pink_wisteria"
+}

--- a/common/src/main/resources/data/botanytrees/loot_table/tree_drops/natures_spirit/purple_wisteria.json
+++ b/common/src/main/resources/data/botanytrees/loot_table/tree_drops/natures_spirit/purple_wisteria.json
@@ -1,0 +1,159 @@
+{
+	"type": "minecraft:block",
+	"pools": [
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"name": "natures_spirit:wisteria_log",
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 4,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					]
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:random_chance",
+							"chance": 0.05
+						}
+					],
+					"name": "natures_spirit:purple_wisteria_sapling"
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:match_tool",
+							"predicate": {
+								"items": "minecraft:shears"
+							}
+						}
+					],
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 3,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					],
+					"name": "natures_spirit:purple_wisteria_leaves"
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:match_tool",
+							"predicate": {
+								"items": "minecraft:shears"
+							}
+						}
+					],
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 3,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					],
+					"name": "natures_spirit:part_purple_wisteria_leaves"
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:match_tool",
+							"predicate": {
+								"items": "minecraft:shears"
+							}
+						}
+					],
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 3,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					],
+					"name": "natures_spirit:wisteria_leaves"
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:match_tool",
+							"predicate": {
+								"items": "minecraft:shears"
+							}
+						}
+					],
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 3,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					],
+					"name": "natures_spirit:purple_wisteria_vines"
+				}
+			],
+			"rolls": 1.0
+		}
+	],
+	"random_sequence": "botanytrees:natures_spirit/purple_wisteria"
+}

--- a/common/src/main/resources/data/botanytrees/loot_table/tree_drops/natures_spirit/red_maple.json
+++ b/common/src/main/resources/data/botanytrees/loot_table/tree_drops/natures_spirit/red_maple.json
@@ -1,0 +1,72 @@
+{
+	"type": "minecraft:block",
+	"pools": [
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"name": "natures_spirit:maple_log",
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 4,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					]
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:random_chance",
+							"chance": 0.05
+						}
+					],
+					"name": "natures_spirit:red_maple_sapling"
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:match_tool",
+							"predicate": {
+								"items": "minecraft:shears"
+							}
+						}
+					],
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 3,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					],
+					"name": "natures_spirit:red_maple_leaves"
+				}
+			],
+			"rolls": 1.0
+		}
+	],
+	"random_sequence": "botanytrees:natures_spirit/red_maple"
+}

--- a/common/src/main/resources/data/botanytrees/loot_table/tree_drops/natures_spirit/redwood.json
+++ b/common/src/main/resources/data/botanytrees/loot_table/tree_drops/natures_spirit/redwood.json
@@ -1,0 +1,72 @@
+{
+	"type": "minecraft:block",
+	"pools": [
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"name": "natures_spirit:redwood_log",
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 4,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					]
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:random_chance",
+							"chance": 0.05
+						}
+					],
+					"name": "natures_spirit:redwood_sapling"
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:match_tool",
+							"predicate": {
+								"items": "minecraft:shears"
+							}
+						}
+					],
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 3,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					],
+					"name": "natures_spirit:redwood_leaves"
+				}
+			],
+			"rolls": 1.0
+		}
+	],
+	"random_sequence": "botanytrees:natures_spirit/redwood"
+}

--- a/common/src/main/resources/data/botanytrees/loot_table/tree_drops/natures_spirit/saxaul.json
+++ b/common/src/main/resources/data/botanytrees/loot_table/tree_drops/natures_spirit/saxaul.json
@@ -1,0 +1,72 @@
+{
+	"type": "minecraft:block",
+	"pools": [
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"name": "natures_spirit:saxaul_log",
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 4,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					]
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:random_chance",
+							"chance": 0.05
+						}
+					],
+					"name": "natures_spirit:saxaul_sapling"
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:match_tool",
+							"predicate": {
+								"items": "minecraft:shears"
+							}
+						}
+					],
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 3,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					],
+					"name": "natures_spirit:saxaul_leaves"
+				}
+			],
+			"rolls": 1.0
+		}
+	],
+	"random_sequence": "botanytrees:natures_spirit/saxaul"
+}

--- a/common/src/main/resources/data/botanytrees/loot_table/tree_drops/natures_spirit/sugi.json
+++ b/common/src/main/resources/data/botanytrees/loot_table/tree_drops/natures_spirit/sugi.json
@@ -1,0 +1,72 @@
+{
+	"type": "minecraft:block",
+	"pools": [
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"name": "natures_spirit:sugi_log",
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 4,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					]
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:random_chance",
+							"chance": 0.05
+						}
+					],
+					"name": "natures_spirit:sugi_sapling"
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:match_tool",
+							"predicate": {
+								"items": "minecraft:shears"
+							}
+						}
+					],
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 3,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					],
+					"name": "natures_spirit:sugi_leaves"
+				}
+			],
+			"rolls": 1.0
+		}
+	],
+	"random_sequence": "botanytrees:natures_spirit/sugi"
+}

--- a/common/src/main/resources/data/botanytrees/loot_table/tree_drops/natures_spirit/white_wisteria.json
+++ b/common/src/main/resources/data/botanytrees/loot_table/tree_drops/natures_spirit/white_wisteria.json
@@ -1,0 +1,159 @@
+{
+	"type": "minecraft:block",
+	"pools": [
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"name": "natures_spirit:wisteria_log",
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 4,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					]
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:random_chance",
+							"chance": 0.05
+						}
+					],
+					"name": "natures_spirit:white_wisteria_sapling"
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:match_tool",
+							"predicate": {
+								"items": "minecraft:shears"
+							}
+						}
+					],
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 3,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					],
+					"name": "natures_spirit:white_wisteria_leaves"
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:match_tool",
+							"predicate": {
+								"items": "minecraft:shears"
+							}
+						}
+					],
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 3,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					],
+					"name": "natures_spirit:part_white_wisteria_leaves"
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:match_tool",
+							"predicate": {
+								"items": "minecraft:shears"
+							}
+						}
+					],
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 3,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					],
+					"name": "natures_spirit:wisteria_leaves"
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:match_tool",
+							"predicate": {
+								"items": "minecraft:shears"
+							}
+						}
+					],
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 3,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					],
+					"name": "natures_spirit:white_wisteria_vines"
+				}
+			],
+			"rolls": 1.0
+		}
+	],
+	"random_sequence": "botanytrees:natures_spirit/white_wisteria"
+}

--- a/common/src/main/resources/data/botanytrees/loot_table/tree_drops/natures_spirit/willow.json
+++ b/common/src/main/resources/data/botanytrees/loot_table/tree_drops/natures_spirit/willow.json
@@ -1,0 +1,72 @@
+{
+	"type": "minecraft:block",
+	"pools": [
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"name": "natures_spirit:willow_log",
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 4,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					]
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:random_chance",
+							"chance": 0.05
+						}
+					],
+					"name": "natures_spirit:willow_sapling"
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:match_tool",
+							"predicate": {
+								"items": "minecraft:shears"
+							}
+						}
+					],
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 3,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					],
+					"name": "natures_spirit:willow_leaves"
+				}
+			],
+			"rolls": 1.0
+		}
+	],
+	"random_sequence": "botanytrees:natures_spirit/willow"
+}

--- a/common/src/main/resources/data/botanytrees/loot_table/tree_drops/natures_spirit/yellow_maple.json
+++ b/common/src/main/resources/data/botanytrees/loot_table/tree_drops/natures_spirit/yellow_maple.json
@@ -1,0 +1,72 @@
+{
+	"type": "minecraft:block",
+	"pools": [
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"name": "natures_spirit:maple_log",
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 4,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					]
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:random_chance",
+							"chance": 0.05
+						}
+					],
+					"name": "natures_spirit:yellow_maple_sapling"
+				}
+			],
+			"rolls": 1.0
+		},
+		{
+			"bonus_rolls": 0.0,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"conditions": [
+						{
+							"condition": "minecraft:match_tool",
+							"predicate": {
+								"items": "minecraft:shears"
+							}
+						}
+					],
+					"functions": [
+						{
+							"add": false,
+							"count": {
+								"type": "minecraft:uniform",
+								"max": 3,
+								"min": 1
+							},
+							"function": "minecraft:set_count"
+						}
+					],
+					"name": "natures_spirit:yellow_maple_leaves"
+				}
+			],
+			"rolls": 1.0
+		}
+	],
+	"random_sequence": "botanytrees:natures_spirit/yellow_maple"
+}

--- a/common/src/main/resources/data/botanytrees/recipe/biomesoplenty/cypress.json
+++ b/common/src/main/resources/data/botanytrees/recipe/biomesoplenty/cypress.json
@@ -1,0 +1,11 @@
+{
+	"type": "botanypots:block_derived_crop",
+	"block": "biomesoplenty:cypress_sapling",
+	"grow_time": 2400,
+	"drops": [
+		{
+			"type": "botanypots:loot_table",
+			"table_id": "botanytrees:tree_drops/biomesoplenty/cypress"
+		}
+	]
+}

--- a/common/src/main/resources/data/botanytrees/recipe/biomesoplenty/dead.json
+++ b/common/src/main/resources/data/botanytrees/recipe/biomesoplenty/dead.json
@@ -1,0 +1,11 @@
+{
+	"type": "botanypots:block_derived_crop",
+	"block": "biomesoplenty:dead_sapling",
+	"grow_time": 2400,
+	"drops": [
+		{
+			"type": "botanypots:loot_table",
+			"table_id": "botanytrees:tree_drops/biomesoplenty/dead"
+		}
+	]
+}

--- a/common/src/main/resources/data/botanytrees/recipe/biomesoplenty/empyreal.json
+++ b/common/src/main/resources/data/botanytrees/recipe/biomesoplenty/empyreal.json
@@ -1,0 +1,11 @@
+{
+	"type": "botanypots:block_derived_crop",
+	"block": "biomesoplenty:empyreal_sapling",
+	"grow_time": 2400,
+	"drops": [
+		{
+			"type": "botanypots:loot_table",
+			"table_id": "botanytrees:tree_drops/biomesoplenty/empyreal"
+		}
+	]
+}

--- a/common/src/main/resources/data/botanytrees/recipe/biomesoplenty/fir.json
+++ b/common/src/main/resources/data/botanytrees/recipe/biomesoplenty/fir.json
@@ -1,0 +1,11 @@
+{
+	"type": "botanypots:block_derived_crop",
+	"block": "biomesoplenty:fir_sapling",
+	"grow_time": 2400,
+	"drops": [
+		{
+			"type": "botanypots:loot_table",
+			"table_id": "botanytrees:tree_drops/biomesoplenty/fir"
+		}
+	]
+}

--- a/common/src/main/resources/data/botanytrees/recipe/biomesoplenty/flowering_oak.json
+++ b/common/src/main/resources/data/botanytrees/recipe/biomesoplenty/flowering_oak.json
@@ -1,0 +1,11 @@
+{
+	"type": "botanypots:block_derived_crop",
+	"block": "biomesoplenty:flowering_oak_sapling",
+	"grow_time": 2400,
+	"drops": [
+		{
+			"type": "botanypots:loot_table",
+			"table_id": "botanytrees:tree_drops/biomesoplenty/flowering_oak"
+		}
+	]
+}

--- a/common/src/main/resources/data/botanytrees/recipe/biomesoplenty/hellbark.json
+++ b/common/src/main/resources/data/botanytrees/recipe/biomesoplenty/hellbark.json
@@ -1,0 +1,11 @@
+{
+	"type": "botanypots:block_derived_crop",
+	"block": "biomesoplenty:hellbark_sapling",
+	"grow_time": 2400,
+	"drops": [
+		{
+			"type": "botanypots:loot_table",
+			"table_id": "botanytrees:tree_drops/biomesoplenty/hellbark"
+		}
+	]
+}

--- a/common/src/main/resources/data/botanytrees/recipe/biomesoplenty/jacaranda.json
+++ b/common/src/main/resources/data/botanytrees/recipe/biomesoplenty/jacaranda.json
@@ -1,0 +1,11 @@
+{
+	"type": "botanypots:block_derived_crop",
+	"block": "biomesoplenty:jacaranda_sapling",
+	"grow_time": 2400,
+	"drops": [
+		{
+			"type": "botanypots:loot_table",
+			"table_id": "botanytrees:tree_drops/biomesoplenty/jacaranda"
+		}
+	]
+}

--- a/common/src/main/resources/data/botanytrees/recipe/biomesoplenty/magic.json
+++ b/common/src/main/resources/data/botanytrees/recipe/biomesoplenty/magic.json
@@ -1,0 +1,11 @@
+{
+	"type": "botanypots:block_derived_crop",
+	"block": "biomesoplenty:magic_sapling",
+	"grow_time": 2400,
+	"drops": [
+		{
+			"type": "botanypots:loot_table",
+			"table_id": "botanytrees:tree_drops/biomesoplenty/magic"
+		}
+	]
+}

--- a/common/src/main/resources/data/botanytrees/recipe/biomesoplenty/mahogany.json
+++ b/common/src/main/resources/data/botanytrees/recipe/biomesoplenty/mahogany.json
@@ -1,0 +1,11 @@
+{
+	"type": "botanypots:block_derived_crop",
+	"block": "biomesoplenty:mahogany_sapling",
+	"grow_time": 2400,
+	"drops": [
+		{
+			"type": "botanypots:loot_table",
+			"table_id": "botanytrees:tree_drops/biomesoplenty/mahogany"
+		}
+	]
+}

--- a/common/src/main/resources/data/botanytrees/recipe/biomesoplenty/orange_maple.json
+++ b/common/src/main/resources/data/botanytrees/recipe/biomesoplenty/orange_maple.json
@@ -1,0 +1,11 @@
+{
+	"type": "botanypots:block_derived_crop",
+	"block": "biomesoplenty:orange_maple_sapling",
+	"grow_time": 2400,
+	"drops": [
+		{
+			"type": "botanypots:loot_table",
+			"table_id": "botanytrees:tree_drops/biomesoplenty/orange_maple"
+		}
+	]
+}

--- a/common/src/main/resources/data/botanytrees/recipe/biomesoplenty/origin.json
+++ b/common/src/main/resources/data/botanytrees/recipe/biomesoplenty/origin.json
@@ -1,0 +1,11 @@
+{
+	"type": "botanypots:block_derived_crop",
+	"block": "biomesoplenty:origin_sapling",
+	"grow_time": 2400,
+	"drops": [
+		{
+			"type": "botanypots:loot_table",
+			"table_id": "botanytrees:tree_drops/biomesoplenty/origin"
+		}
+	]
+}

--- a/common/src/main/resources/data/botanytrees/recipe/biomesoplenty/palm.json
+++ b/common/src/main/resources/data/botanytrees/recipe/biomesoplenty/palm.json
@@ -1,0 +1,11 @@
+{
+	"type": "botanypots:block_derived_crop",
+	"block": "biomesoplenty:palm_sapling",
+	"grow_time": 2400,
+	"drops": [
+		{
+			"type": "botanypots:loot_table",
+			"table_id": "botanytrees:tree_drops/biomesoplenty/palm"
+		}
+	]
+}

--- a/common/src/main/resources/data/botanytrees/recipe/biomesoplenty/pine.json
+++ b/common/src/main/resources/data/botanytrees/recipe/biomesoplenty/pine.json
@@ -1,0 +1,11 @@
+{
+	"type": "botanypots:block_derived_crop",
+	"block": "biomesoplenty:pine_sapling",
+	"grow_time": 2400,
+	"drops": [
+		{
+			"type": "botanypots:loot_table",
+			"table_id": "botanytrees:tree_drops/biomesoplenty/pine"
+		}
+	]
+}

--- a/common/src/main/resources/data/botanytrees/recipe/biomesoplenty/rainbow_birch.json
+++ b/common/src/main/resources/data/botanytrees/recipe/biomesoplenty/rainbow_birch.json
@@ -1,0 +1,11 @@
+{
+	"type": "botanypots:block_derived_crop",
+	"block": "biomesoplenty:rainbow_birch_sapling",
+	"grow_time": 2400,
+	"drops": [
+		{
+			"type": "botanypots:loot_table",
+			"table_id": "botanytrees:tree_drops/biomesoplenty/rainbow_birch"
+		}
+	]
+}

--- a/common/src/main/resources/data/botanytrees/recipe/biomesoplenty/red_maple.json
+++ b/common/src/main/resources/data/botanytrees/recipe/biomesoplenty/red_maple.json
@@ -1,0 +1,11 @@
+{
+	"type": "botanypots:block_derived_crop",
+	"block": "biomesoplenty:red_maple_sapling",
+	"grow_time": 2400,
+	"drops": [
+		{
+			"type": "botanypots:loot_table",
+			"table_id": "botanytrees:tree_drops/biomesoplenty/red_maple"
+		}
+	]
+}

--- a/common/src/main/resources/data/botanytrees/recipe/biomesoplenty/redwood.json
+++ b/common/src/main/resources/data/botanytrees/recipe/biomesoplenty/redwood.json
@@ -1,0 +1,11 @@
+{
+	"type": "botanypots:block_derived_crop",
+	"block": "biomesoplenty:redwood_sapling",
+	"grow_time": 2400,
+	"drops": [
+		{
+			"type": "botanypots:loot_table",
+			"table_id": "botanytrees:tree_drops/biomesoplenty/redwood"
+		}
+	]
+}

--- a/common/src/main/resources/data/botanytrees/recipe/biomesoplenty/snowblossom.json
+++ b/common/src/main/resources/data/botanytrees/recipe/biomesoplenty/snowblossom.json
@@ -1,0 +1,11 @@
+{
+	"type": "botanypots:block_derived_crop",
+	"block": "biomesoplenty:snowblossom_sapling",
+	"grow_time": 2400,
+	"drops": [
+		{
+			"type": "botanypots:loot_table",
+			"table_id": "botanytrees:tree_drops/biomesoplenty/snowblossom"
+		}
+	]
+}

--- a/common/src/main/resources/data/botanytrees/recipe/biomesoplenty/umbran.json
+++ b/common/src/main/resources/data/botanytrees/recipe/biomesoplenty/umbran.json
@@ -1,0 +1,11 @@
+{
+	"type": "botanypots:block_derived_crop",
+	"block": "biomesoplenty:umbran_sapling",
+	"grow_time": 2400,
+	"drops": [
+		{
+			"type": "botanypots:loot_table",
+			"table_id": "botanytrees:tree_drops/biomesoplenty/umbran"
+		}
+	]
+}

--- a/common/src/main/resources/data/botanytrees/recipe/biomesoplenty/willow.json
+++ b/common/src/main/resources/data/botanytrees/recipe/biomesoplenty/willow.json
@@ -1,0 +1,11 @@
+{
+	"type": "botanypots:block_derived_crop",
+	"block": "biomesoplenty:willow_sapling",
+	"grow_time": 2400,
+	"drops": [
+		{
+			"type": "botanypots:loot_table",
+			"table_id": "botanytrees:tree_drops/biomesoplenty/willow"
+		}
+	]
+}

--- a/common/src/main/resources/data/botanytrees/recipe/biomesoplenty/yellow_maple.json
+++ b/common/src/main/resources/data/botanytrees/recipe/biomesoplenty/yellow_maple.json
@@ -1,0 +1,11 @@
+{
+	"type": "botanypots:block_derived_crop",
+	"block": "biomesoplenty:yellow_maple_sapling",
+	"grow_time": 2400,
+	"drops": [
+		{
+			"type": "botanypots:loot_table",
+			"table_id": "botanytrees:tree_drops/biomesoplenty/yellow_maple"
+		}
+	]
+}

--- a/common/src/main/resources/data/botanytrees/recipe/natures_spirit/aspen.json
+++ b/common/src/main/resources/data/botanytrees/recipe/natures_spirit/aspen.json
@@ -1,0 +1,11 @@
+{
+	"type": "botanypots:block_derived_crop",
+	"block": "natures_spirit:aspen_sapling",
+	"grow_time": 2400,
+	"drops": [
+		{
+			"type": "botanypots:loot_table",
+			"table_id": "botanytrees:tree_drops/natures_spirit/aspen"
+		}
+	]
+}

--- a/common/src/main/resources/data/botanytrees/recipe/natures_spirit/blue_wisteria.json
+++ b/common/src/main/resources/data/botanytrees/recipe/natures_spirit/blue_wisteria.json
@@ -1,0 +1,11 @@
+{
+	"type": "botanypots:block_derived_crop",
+	"block": "natures_spirit:blue_wisteria_sapling",
+	"grow_time": 2400,
+	"drops": [
+		{
+			"type": "botanypots:loot_table",
+			"table_id": "botanytrees:tree_drops/natures_spirit/blue_wisteria"
+		}
+	]
+}

--- a/common/src/main/resources/data/botanytrees/recipe/natures_spirit/cedar.json
+++ b/common/src/main/resources/data/botanytrees/recipe/natures_spirit/cedar.json
@@ -1,0 +1,11 @@
+{
+	"type": "botanypots:block_derived_crop",
+	"block": "natures_spirit:cedar_sapling",
+	"grow_time": 2400,
+	"drops": [
+		{
+			"type": "botanypots:loot_table",
+			"table_id": "botanytrees:tree_drops/natures_spirit/cedar"
+		}
+	]
+}

--- a/common/src/main/resources/data/botanytrees/recipe/natures_spirit/cypress.json
+++ b/common/src/main/resources/data/botanytrees/recipe/natures_spirit/cypress.json
@@ -1,0 +1,11 @@
+{
+	"type": "botanypots:block_derived_crop",
+	"block": "natures_spirit:cypress_sapling",
+	"grow_time": 2400,
+	"drops": [
+		{
+			"type": "botanypots:loot_table",
+			"table_id": "botanytrees:tree_drops/natures_spirit/cypress"
+		}
+	]
+}

--- a/common/src/main/resources/data/botanytrees/recipe/natures_spirit/fir.json
+++ b/common/src/main/resources/data/botanytrees/recipe/natures_spirit/fir.json
@@ -1,0 +1,11 @@
+{
+	"type": "botanypots:block_derived_crop",
+	"block": "natures_spirit:fir_sapling",
+	"grow_time": 2400,
+	"drops": [
+		{
+			"type": "botanypots:loot_table",
+			"table_id": "botanytrees:tree_drops/natures_spirit/fir"
+		}
+	]
+}

--- a/common/src/main/resources/data/botanytrees/recipe/natures_spirit/ghaf.json
+++ b/common/src/main/resources/data/botanytrees/recipe/natures_spirit/ghaf.json
@@ -1,0 +1,11 @@
+{
+	"type": "botanypots:block_derived_crop",
+	"block": "natures_spirit:ghaf_sapling",
+	"grow_time": 2400,
+	"drops": [
+		{
+			"type": "botanypots:loot_table",
+			"table_id": "botanytrees:tree_drops/natures_spirit/ghaf"
+		}
+	]
+}

--- a/common/src/main/resources/data/botanytrees/recipe/natures_spirit/joshua.json
+++ b/common/src/main/resources/data/botanytrees/recipe/natures_spirit/joshua.json
@@ -1,0 +1,11 @@
+{
+	"type": "botanypots:block_derived_crop",
+	"block": "natures_spirit:joshua_sapling",
+	"grow_time": 2400,
+	"drops": [
+		{
+			"type": "botanypots:loot_table",
+			"table_id": "botanytrees:tree_drops/natures_spirit/joshua"
+		}
+	]
+}

--- a/common/src/main/resources/data/botanytrees/recipe/natures_spirit/larch.json
+++ b/common/src/main/resources/data/botanytrees/recipe/natures_spirit/larch.json
@@ -1,0 +1,11 @@
+{
+	"type": "botanypots:block_derived_crop",
+	"block": "natures_spirit:larch_sapling",
+	"grow_time": 2400,
+	"drops": [
+		{
+			"type": "botanypots:loot_table",
+			"table_id": "botanytrees:tree_drops/natures_spirit/larch"
+		}
+	]
+}

--- a/common/src/main/resources/data/botanytrees/recipe/natures_spirit/mahogany.json
+++ b/common/src/main/resources/data/botanytrees/recipe/natures_spirit/mahogany.json
@@ -1,0 +1,11 @@
+{
+	"type": "botanypots:block_derived_crop",
+	"block": "natures_spirit:mahogany_sapling",
+	"grow_time": 2400,
+	"drops": [
+		{
+			"type": "botanypots:loot_table",
+			"table_id": "botanytrees:tree_drops/natures_spirit/mahogany"
+		}
+	]
+}

--- a/common/src/main/resources/data/botanytrees/recipe/natures_spirit/olive.json
+++ b/common/src/main/resources/data/botanytrees/recipe/natures_spirit/olive.json
@@ -1,0 +1,11 @@
+{
+	"type": "botanypots:block_derived_crop",
+	"block": "natures_spirit:olive_sapling",
+	"grow_time": 2400,
+	"drops": [
+		{
+			"type": "botanypots:loot_table",
+			"table_id": "botanytrees:tree_drops/natures_spirit/olive"
+		}
+	]
+}

--- a/common/src/main/resources/data/botanytrees/recipe/natures_spirit/orange_maple.json
+++ b/common/src/main/resources/data/botanytrees/recipe/natures_spirit/orange_maple.json
@@ -1,0 +1,11 @@
+{
+	"type": "botanypots:block_derived_crop",
+	"block": "natures_spirit:orange_maple_sapling",
+	"grow_time": 2400,
+	"drops": [
+		{
+			"type": "botanypots:loot_table",
+			"table_id": "botanytrees:tree_drops/natures_spirit/orange_maple"
+		}
+	]
+}

--- a/common/src/main/resources/data/botanytrees/recipe/natures_spirit/palo_verde.json
+++ b/common/src/main/resources/data/botanytrees/recipe/natures_spirit/palo_verde.json
@@ -1,0 +1,11 @@
+{
+	"type": "botanypots:block_derived_crop",
+	"block": "natures_spirit:palo_verde_sapling",
+	"grow_time": 2400,
+	"drops": [
+		{
+			"type": "botanypots:loot_table",
+			"table_id": "botanytrees:tree_drops/natures_spirit/palo_verde"
+		}
+	]
+}

--- a/common/src/main/resources/data/botanytrees/recipe/natures_spirit/pink_wisteria.json
+++ b/common/src/main/resources/data/botanytrees/recipe/natures_spirit/pink_wisteria.json
@@ -1,0 +1,11 @@
+{
+	"type": "botanypots:block_derived_crop",
+	"block": "natures_spirit:pink_wisteria_sapling",
+	"grow_time": 2400,
+	"drops": [
+		{
+			"type": "botanypots:loot_table",
+			"table_id": "botanytrees:tree_drops/natures_spirit/pink_wisteria"
+		}
+	]
+}

--- a/common/src/main/resources/data/botanytrees/recipe/natures_spirit/purple_wisteria.json
+++ b/common/src/main/resources/data/botanytrees/recipe/natures_spirit/purple_wisteria.json
@@ -1,0 +1,11 @@
+{
+	"type": "botanypots:block_derived_crop",
+	"block": "natures_spirit:purple_wisteria_sapling",
+	"grow_time": 2400,
+	"drops": [
+		{
+			"type": "botanypots:loot_table",
+			"table_id": "botanytrees:tree_drops/natures_spirit/purple_wisteria"
+		}
+	]
+}

--- a/common/src/main/resources/data/botanytrees/recipe/natures_spirit/red_maple.json
+++ b/common/src/main/resources/data/botanytrees/recipe/natures_spirit/red_maple.json
@@ -1,0 +1,11 @@
+{
+	"type": "botanypots:block_derived_crop",
+	"block": "natures_spirit:red_maple_sapling",
+	"grow_time": 2400,
+	"drops": [
+		{
+			"type": "botanypots:loot_table",
+			"table_id": "botanytrees:tree_drops/natures_spirit/red_maple"
+		}
+	]
+}

--- a/common/src/main/resources/data/botanytrees/recipe/natures_spirit/redwood.json
+++ b/common/src/main/resources/data/botanytrees/recipe/natures_spirit/redwood.json
@@ -1,0 +1,11 @@
+{
+	"type": "botanypots:block_derived_crop",
+	"block": "natures_spirit:redwood_sapling",
+	"grow_time": 2400,
+	"drops": [
+		{
+			"type": "botanypots:loot_table",
+			"table_id": "botanytrees:tree_drops/natures_spirit/redwood"
+		}
+	]
+}

--- a/common/src/main/resources/data/botanytrees/recipe/natures_spirit/saxaul.json
+++ b/common/src/main/resources/data/botanytrees/recipe/natures_spirit/saxaul.json
@@ -1,0 +1,11 @@
+{
+	"type": "botanypots:block_derived_crop",
+	"block": "natures_spirit:saxaul_sapling",
+	"grow_time": 2400,
+	"drops": [
+		{
+			"type": "botanypots:loot_table",
+			"table_id": "botanytrees:tree_drops/natures_spirit/saxaul"
+		}
+	]
+}

--- a/common/src/main/resources/data/botanytrees/recipe/natures_spirit/sugi.json
+++ b/common/src/main/resources/data/botanytrees/recipe/natures_spirit/sugi.json
@@ -1,0 +1,11 @@
+{
+	"type": "botanypots:block_derived_crop",
+	"block": "natures_spirit:sugi_sapling",
+	"grow_time": 2400,
+	"drops": [
+		{
+			"type": "botanypots:loot_table",
+			"table_id": "botanytrees:tree_drops/natures_spirit/sugi"
+		}
+	]
+}

--- a/common/src/main/resources/data/botanytrees/recipe/natures_spirit/white_wisteria.json
+++ b/common/src/main/resources/data/botanytrees/recipe/natures_spirit/white_wisteria.json
@@ -1,0 +1,11 @@
+{
+	"type": "botanypots:block_derived_crop",
+	"block": "natures_spirit:white_wisteria_sapling",
+	"grow_time": 2400,
+	"drops": [
+		{
+			"type": "botanypots:loot_table",
+			"table_id": "botanytrees:tree_drops/natures_spirit/white_wisteria"
+		}
+	]
+}

--- a/common/src/main/resources/data/botanytrees/recipe/natures_spirit/willow.json
+++ b/common/src/main/resources/data/botanytrees/recipe/natures_spirit/willow.json
@@ -1,0 +1,11 @@
+{
+	"type": "botanypots:block_derived_crop",
+	"block": "natures_spirit:willow_sapling",
+	"grow_time": 2400,
+	"drops": [
+		{
+			"type": "botanypots:loot_table",
+			"table_id": "botanytrees:tree_drops/natures_spirit/willow"
+		}
+	]
+}

--- a/common/src/main/resources/data/botanytrees/recipe/natures_spirit/yellow_maple.json
+++ b/common/src/main/resources/data/botanytrees/recipe/natures_spirit/yellow_maple.json
@@ -1,0 +1,11 @@
+{
+	"type": "botanypots:block_derived_crop",
+	"block": "natures_spirit:yellow_maple_sapling",
+	"grow_time": 2400,
+	"drops": [
+		{
+			"type": "botanypots:loot_table",
+			"table_id": "botanytrees:tree_drops/natures_spirit/yellow_maple"
+		}
+	]
+}


### PR DESCRIPTION
Adds support back for Biomes O Plenty and Nature's Spirit saplings, as all mod compats are missing in the 1.21.1 port